### PR TITLE
RDF::URI#join adds an unnecessary slash to self

### DIFF
--- a/lib/rdf/model/uri.rb
+++ b/lib/rdf/model/uri.rb
@@ -134,7 +134,7 @@ module RDF
     # @param  [Array<String, URI, #to_str>] uris
     # @return [URI]
     def join(*uris)
-      result = @uri
+      result = @uri.dup
       uris.each do |uri|
         result.path += '/' unless result.path[-1] == ?/ # '/'
         result = result.join(uri)


### PR DESCRIPTION
<pre>
>> require 'rdf'
=> true
>> uri = RDF::URI('http://example.com/foo')
=> #&lt;RDF::URI:0x3fd190c41b24(http://example.com/foo)&gt;
>> uri.join('bar')
=> #&lt;RDF::URI:0x3fd1901cd7ec(http://example.com/foo/bar)&gt;
>> uri
=> #&lt;RDF::URI:0x3fd190c41b24(http://example.com/foo/)&gt;
</pre>
