### PR TITLE
Small fix in N-Triples parser

### DIFF
--- a/lib/rdf/ntriples/reader.rb
+++ b/lib/rdf/ntriples/reader.rb
@@ -33,9 +33,9 @@ module RDF::NTriples
     NODEID                = /^_:([A-Za-z][A-Za-z0-9]*)/.freeze
     URIREF                = /^<([^>]+)>/.freeze
     LITERAL_PLAIN         = /^"((?:\\"|[^"])*)"/.freeze
-    LITERAL_WITH_LANGUAGE = /^"((?:\\"|[^"])*)"@([a-z]+[\-a-z0-9]*)/.freeze
+    LITERAL_WITH_LANGUAGE = /^"((?:\\"|[^"])*)"@([a-z]+[\-A-Z0-9]*)/.freeze
     LITERAL_WITH_DATATYPE = /^"((?:\\"|[^"])*)"\^\^<([^>]+)>/.freeze
-    LANGUAGE_TAG          = /^@([a-z]+[\-a-z0-9]*)/.freeze
+    LANGUAGE_TAG          = /^@([a-z]+[\-A-Z0-9]*)/.freeze
     DATATYPE_URI          = /^\^\^<([^>]+)>/.freeze
     LITERAL               = Regexp.union(LITERAL_WITH_LANGUAGE, LITERAL_WITH_DATATYPE, LITERAL_PLAIN).freeze
     SUBJECT               = Regexp.union(URIREF, NODEID).freeze


### PR DESCRIPTION
In literals with languages, the country code tag after the language code is usually uppercased (ex: en-US). The xml specs appear to allow more complex formats for this extension tag, but country code is most common, and that is upper case.
