### PR TITLE
Allow _ and - in blank node identifiers (after first character)

### DIFF
--- a/lib/rdf/ntriples/reader.rb
+++ b/lib/rdf/ntriples/reader.rb
@@ -30,7 +30,7 @@ module RDF::NTriples
 
     # @see http://www.w3.org/TR/rdf-testcases/#ntrip_grammar
     COMMENT               = /^#\s*(.*)$/.freeze
-    NODEID                = /^_:([A-Za-z][A-Za-z0-9]*)/.freeze
+    NODEID                = /^_:([A-Za-z][A-Za-z0-9\-_]*)/.freeze
     URIREF                = /^<([^>]+)>/.freeze
     LITERAL_PLAIN         = /^"((?:\\"|[^"])*)"/.freeze
     LITERAL_WITH_LANGUAGE = /^"((?:\\"|[^"])*)"@([a-z]+[\-A-Za-z0-9]*)/.freeze


### PR DESCRIPTION
The berlin SP2B benchmarks are littered with nodes identified with underscores, and rapper is too careless not to output them when trying to convert from n3.  This patch allows node IDs with underscores, and dashes to boot.
