### PR TITLE
Improve BGP query loop performance

### DIFF
--- a/lib/rdf/query.rb
+++ b/lib/rdf/query.rb
@@ -190,8 +190,8 @@ module RDF
                 end
               else # union
                 old_solutions, @solutions = @solutions, Solutions.new
-                old_solutions.each do |solution|
-                  pattern.execute(queryable) do |statement|
+                pattern.execute(queryable) do |statement|
+                  old_solutions.each do |solution|
                     @solutions << solution.merge(pattern.solution(statement))
                   end
                 end


### PR DESCRIPTION
This change is dramatic improvement for almost any BGP with multiple patterns for reasons that are hopefully obvious looking at the changeset; James running 5-pattern queries against 50k triples went from 'never finishes' to '2s'.  No tests fail but I don't know how comprehensive they are.  Seems like it ought to be equivalent semantically.
