### PR TITLE
Support default prefixes in readers/writers

### DIFF
--- a/lib/rdf/reader.rb
+++ b/lib/rdf/reader.rb
@@ -221,8 +221,8 @@ module RDF
     #
     # @return [RDF::URI]
     def prefix(name, uri = nil)
-      name = name.respond_to?(:to_sym) ? name.to_sym : name.to_s.to_sym
-      uri.nil? ? prefixes[name] : prefixes[name] = RDF::URI(uri)
+      name = name.to_s.empty? ? nil : (name.respond_to?(:to_sym) ? name.to_sym : name.to_s.to_sym)
+      uri.nil? ? prefixes[name] : prefixes[name] = (uri.respond_to?(:to_sym) ? uri.to_sym : uri.to_s.to_sym)
     end
     alias_method :prefix!, :prefix
 

--- a/lib/rdf/writer.rb
+++ b/lib/rdf/writer.rb
@@ -238,8 +238,8 @@ module RDF
     #
     # @return [RDF::URI]
     def prefix(name, uri = nil)
-      name = name.respond_to?(:to_sym) ? name.to_sym : name.to_s.to_sym
-      uri.nil? ? prefixes[name] : prefixes[name] = RDF::URI(uri)
+      name = name.to_s.empty? ? nil : (name.respond_to?(:to_sym) ? name.to_sym : name.to_s.to_sym)
+      uri.nil? ? prefixes[name] : prefixes[name] = (uri.respond_to?(:to_sym) ? uri.to_sym : uri.to_s.to_sym)
     end
     alias_method :prefix!, :prefix
 


### PR DESCRIPTION
This is the change to Reader#prefix() and Writer#prefix() to allow for an empty or nil prefix. It is required to pass tests in N3 and RDF/XML.
