### PR TITLE
Double/Decimal c14n equivalence

### DIFF
--- a/lib/rdf/model/literal/decimal.rb
+++ b/lib/rdf/model/literal/decimal.rb
@@ -45,6 +45,7 @@ module RDF; class Literal
         f = '0' if f.empty?         # ...but there must be a digit to the right of the decimal point
         "#{i}.#{f}"
       end
+      @object = BigDecimal(@string) unless @object.nil?
       self
     end
 

--- a/lib/rdf/model/literal/double.rb
+++ b/lib/rdf/model/literal/double.rb
@@ -54,7 +54,8 @@ module RDF; class Literal
           f = '0' if f.empty?         # ...but there must be a digit to the right of the decimal point
           e.sub!(/^\+?0+(\d)$/, '\1') # remove the optional leading '+' sign and any extra leading zeroes
           "#{i}.#{f}E#{e}"
-      end unless @object.nil?
+      end
+      @object = Float(@string) unless @object.nil?
       self
     end
 


### PR DESCRIPTION
This bug was causing N3 specs to fail. After canonicalization, a literal should compare equal to another literal with the same representation after c14n. The fix does this by updating the @object representation after c14n.
