### PR TITLE
RDF::Enumerable#dump options

### DIFF
--- a/lib/rdf/mixin/enumerable.rb
+++ b/lib/rdf/mixin/enumerable.rb
@@ -607,11 +607,14 @@ module RDF
     #   ntriples = enumerable.dump(:ntriples)
     #
     # @param  [Array<Object>] args
+    #   The first element is passed to Writer.for.
+    #   If the last argument is a hash, it is passed to Writer.dump as options
     # @return [String]
     # @see    RDF::Writer.dump
     # @since  0.2.0
     def dump(*args)
-      RDF::Writer.for(*args).dump(self)
+      opts = args.last.is_a?(Hash) ? args.last : {}
+      RDF::Writer.for(args.first).dump(self, nil, opts)
     end
   end # Enumerable
 end # RDF

--- a/lib/rdf/writer.rb
+++ b/lib/rdf/writer.rb
@@ -104,20 +104,20 @@ module RDF
     ##
     # @param  [Object]                 data
     # @param  [IO, File]               io
-    # @param  [Hash{Symbol => Object}] options
+    # @param  [Hash{Symbol => Object}] options Passed to Writer.new or Writer.buffer
     # @return [void]
     def self.dump(data, io = nil, options = {})
       io = File.open(io, 'w') if io.is_a?(String)
       method = data.respond_to?(:each_statement) ? :each_statement : :each
       if io
-        new(io) do |writer|
+        new(io, options) do |writer|
           data.send(method) do |statement|
             writer << statement
           end
           writer.flush
         end
       else
-        buffer do |writer|
+        buffer(options) do |writer|
           data.send(method) do |statement|
             writer << statement
           end


### PR DESCRIPTION
This patch addresses an issue raised by njh on passing options to a writer as decribed in https://github.com/gkellogg/rdf-rdfxml/issues/issue/3. He has a work-around, so it can certainly wait for the next release.
