### PR TITLE
Change to allow Writer options to be passed to dump() methods

### DIFF
--- a/lib/rdf/mixin/enumerable.rb
+++ b/lib/rdf/mixin/enumerable.rb
@@ -610,8 +610,8 @@ module RDF
     # @return [String]
     # @see    RDF::Writer.dump
     # @since  0.2.0
-    def dump(*args)
-      RDF::Writer.for(*args).dump(self)
+    def dump(format, options={})
+      RDF::Writer.for(format).dump(self, nil, options)
     end
   end # Enumerable
 end # RDF

--- a/lib/rdf/writer.rb
+++ b/lib/rdf/writer.rb
@@ -110,14 +110,14 @@ module RDF
       io = File.open(io, 'w') if io.is_a?(String)
       method = data.respond_to?(:each_statement) ? :each_statement : :each
       if io
-        new(io) do |writer|
+        new(io, options) do |writer|
           data.send(method) do |statement|
             writer << statement
           end
           writer.flush
         end
       else
-        buffer do |writer|
+        buffer(options) do |writer|
           data.send(method) do |statement|
             writer << statement
           end


### PR DESCRIPTION
Hello,

Attached is a patch to allow Writer options to be passed to dump() methods.

Example:

```
graph = RDF::Graph.new do |g|
  g << [RDF::URI('http://example.com/joe'), RDF::FOAF.name, "Joe Bloggs"]
end

puts graph.dump(:rdfxml, :standard_prefixes => true)
```

Thanks!

nick.
