### PR TITLE
RDF::Query and optional patterns

### DIFF
--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -321,6 +321,29 @@ describe RDF::Query do
           {:s => EX.s2, :o => EX.o2}
         ].to_set
       end
+
+      it "should raise an error unless all optional patterns follow regular patterns" do
+        # SPARQL requires optional patterns to follow the regular patterns.
+        # In the interest of compatibility, we enforce similar
+        # restrictions, because the semantics of leading optional patterns
+        # are hard to get right.
+        lambda do
+          query = RDF::Query.new do |query|
+            query.pattern [:s, EX.p2, :o], :optional => true
+            query.pattern [:s, EX.p, EX.o]
+          end
+          query.execute(@graph)
+        end.should raise_error(ArgumentError)
+
+        lambda do
+          query = RDF::Query.new do |query|
+            query.pattern [:s, EX.p, EX.o]
+            query.pattern [:s, EX.p2, :o], :optional => true
+            query.pattern [:s, EX.x, EX.x]
+          end
+          query.execute(@graph)
+        end.should raise_error(ArgumentError)
+      end
     end
 
     context "with preliminary bindings" do


### PR DESCRIPTION
Greetings! Thank you for all your work on RDF.rb, and for helping me build a new repository adapter.

While writing unit tests for RDF::Repository#query_execute, I ran into an interesting corner-case: Optional patterns did not seem to generate matches. After writing some unit tests, I discovered that the logic in RDF::Query#execute didn't implement optional patterns with same semantics as SPARQL. Since there weren't any existing specs for optional patterns, I decided that this was probably an incomplete implementation, added some specs, and tweaked RDF::Query#execute to get the same answers as SPARQL.

Once that was done, I noticed an interesting issue with the ordering of 'optional' clauses, consulted the SPARQL specification again, and decided to punt on the issue. See the patch description for a discussion of what's going on here.

The client funding this work states "unlicense is ok with us for RDF.rf patches you provide", and I agree to the following statement:

"I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law."

If you need more than that, I'll ask my client.

Thank you for reviewing my patch, and please don't hesitate to ask me to make changes! RDF.rb is a lovely library, and I'm delighted to be working with it.
