### PR TITLE
Reader format error

### DIFF
--- a/lib/rdf/nquads.rb
+++ b/lib/rdf/nquads.rb
@@ -4,9 +4,24 @@ module RDF
   #
   # This has not yet been implemented as of RDF.rb 0.3.x.
   module NQuads
-    class Format < NTriples::Format
-      # TODO
-    end # Format
+    ##
+    # N-Quads format specification.
+    #
+    # @example Obtaining an NQuads format class
+    #   RDF::Format.for(:nquads)     #=> RDF::NQuads::Format
+    #   RDF::Format.for("etc/doap.nq")
+    #   RDF::Format.for(:file_name      => "etc/doap.nq")
+    #   RDF::Format.for(:file_extension => "nq")
+    #   RDF::Format.for(:content_type   => "text/x-nquads")
+    #
+    # @see http://sw.deri.org/2008/07/n-quads/#mediatype
+    class Format < RDF::Format
+      content_type     'text/x-nquads', :extension => :nq
+      content_encoding 'ascii'
+
+      reader { RDF::NQuads::Reader }
+      writer { RDF::NQuads::Writer }
+    end
 
     class Reader < NTriples::Reader
       # TODO

--- a/lib/rdf/reader.rb
+++ b/lib/rdf/reader.rb
@@ -118,11 +118,11 @@ module RDF
         format_options = options.dup
         format_options[:content_type] ||= file.content_type if file.respond_to?(:content_type)
         format_options[:file_name] ||= filename
-        reader = self.for(format_options)
+        reader = self.for(format_options[:format] || format_options)
         if reader
           reader.new(file, options, &block)
         else
-          raise FormatError, "unknown RDF format: #{options[:format] || {:file_name => filename, :content_type => content_type}.inspect}"
+          raise FormatError, "unknown RDF format: #{format_options.inspect}"
         end
       end
     end

--- a/lib/rdf/writer.rb
+++ b/lib/rdf/writer.rb
@@ -147,12 +147,14 @@ module RDF
     #
     # @param  [String, #to_s] filename
     # @param  [Hash{Symbol => Object}] options
-    #   any additional options (see {RDF::Writer#initialize})
+    #   any additional options (see {RDF::Writer#initialize and {RDF::Format.for}})
     # @option options [Symbol] :format (nil)
     # @return [RDF::Writer]
     def self.open(filename, options = {}, &block)
       File.open(filename, 'wb') do |file|
-        self.for(options[:format] || filename).new(file, options, &block)
+        format_options = options.dup
+        format_options[:file_name] ||= filename
+        self.for(options[:format] || format_options).new(file, options, &block)
       end
     end
 

--- a/spec/format_spec.rb
+++ b/spec/format_spec.rb
@@ -1,5 +1,11 @@
 require File.join(File.dirname(__FILE__), 'spec_helper')
+require 'rdf/spec/format'
 
 describe RDF::Format do
-  # TODO
+  before(:each) do
+    @format_class = RDF::Format
+  end
+  
+  # @see lib/rdf/spec/format.rb in rdf-spec
+  it_should_behave_like RDF_Format
 end

--- a/spec/nquads_spec.rb
+++ b/spec/nquads_spec.rb
@@ -1,9 +1,17 @@
 # -*- encoding: utf-8 -*-
 require File.join(File.dirname(__FILE__), 'spec_helper')
 require 'rdf/nquads'
+require 'rdf/spec/format'
+require 'rdf/spec/reader'
 
 describe RDF::NQuads::Format do
   before(:each) { pending "N-Quads is not supported yet" }
+  before(:each) do
+    @format_class = RDF::NQuads::Format
+  end
+  
+  # @see lib/rdf/spec/format.rb in rdf-spec
+  it_should_behave_like RDF_Format
 
   it "should be discoverable" do
     formats = [
@@ -19,6 +27,13 @@ end
 
 describe RDF::NQuads::Reader do
   before(:each) { pending "N-Quads is not supported yet" }
+  before(:each) do
+    @reader = RDF::NQuads::Reader.new
+  end
+  
+  # @see lib/rdf/spec/reader.rb in rdf-spec
+  it_should_behave_like RDF_Reader
+
 
   it "should be discoverable" do
     readers = [

--- a/spec/ntriples_spec.rb
+++ b/spec/ntriples_spec.rb
@@ -1,8 +1,17 @@
 # -*- encoding: utf-8 -*-
 require File.join(File.dirname(__FILE__), 'spec_helper')
 require 'rdf/ntriples'
+require 'rdf/spec/format'
+require 'rdf/spec/reader'
 
 describe RDF::NTriples::Format do
+  before(:each) do
+    @format_class = RDF::NTriples::Format
+  end
+  
+  # @see lib/rdf/spec/format.rb in rdf-spec
+  it_should_behave_like RDF_Format
+
   it "should be discoverable" do
     formats = [
       RDF::Format.for(:ntriples),
@@ -16,6 +25,13 @@ describe RDF::NTriples::Format do
 end
 
 describe RDF::NTriples::Reader do
+  before(:each) do
+    @reader = RDF::NTriples::Reader.new
+  end
+  
+  # @see lib/rdf/spec/reader.rb in rdf-spec
+  it_should_behave_like RDF_Reader
+
   it "should be discoverable" do
     readers = [
       RDF::Reader.for(:ntriples),
@@ -197,6 +213,21 @@ describe RDF::NTriples do
       stmt.should be_a_statement
     end
 
+    describe "with nodes" do
+      it "should read two named nodes as the same node" do
+        stmt = @reader.unserialize("_:a <http://www.w3.org/2002/07/owl#sameAs> _:a .")
+        stmt.subject.should == stmt.object
+        stmt.subject.should be_eql(stmt.object)
+      end
+      
+      it "should read two named nodes in different instances as different nodes" do
+        stmt1 = @reader.unserialize("_:a <http://www.w3.org/2002/07/owl#sameAs> _:a .")
+        stmt2 = @reader.unserialize("_:a <http://www.w3.org/2002/07/owl#sameAs> _:a .")
+        stmt1.subject.should == stmt2.subject
+        stmt1.subject.should_not be_eql(stmt2.subject)
+      end
+    end
+    
     describe "with literal encodings" do
       {
         'Dürst'          => '_:a <http://pred> "D\u00FCrst" .',

--- a/spec/readme_spec.rb
+++ b/spec/readme_spec.rb
@@ -52,7 +52,7 @@ describe 'README' do
     def example2
       require 'rdf/ntriples'
 
-      RDF::Reader.open("http://rdf.rubyforge.org/doap.nt") do |reader|
+      RDF::NTriples::Reader.open("http://rdf.rubyforge.org/doap.nt") do |reader|
         reader.each_statement do |statement|
           puts statement.inspect
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,8 @@ require 'rdf/spec/matchers'
 
 RSpec.configure do |config|
   config.include(RDF::Spec::Matchers)
+  config.filter_run :focus => true
+  config.run_all_when_everything_filtered = true
   config.exclusion_filter = {:ruby => lambda { |version|
     RUBY_VERSION.to_s !~ /^#{version}/
   }}


### PR DESCRIPTION
This is an extract from the query-algebra branch, which includes urgent changes (urgent since January!) that should go into the 0.3 branch. In particular, there is a bit in Reader.open (and Writer.open) where open(filename, :format => :ntriples) does not work properly. And, there was a problem in the error message.

Additionally, I've added specs for Format and included shared specs for Reader and Writer in NTriples and NQuads.
