### PR TITLE
Graph support for statements with context

### DIFF
--- a/lib/rdf/model/graph.rb
+++ b/lib/rdf/model/graph.rb
@@ -178,9 +178,7 @@ module RDF
     # @return [Boolean]
     # @see    RDF::Enumerable#has_statement?
     def has_statement?(statement)
-      statement = statement.dup
-      statement.context = context
-      @data.has_statement?(statement)
+      @data.has_statement?(duplicate_statement(statement))
     end
 
     ##
@@ -191,34 +189,28 @@ module RDF
     # @return [Enumerator]
     # @see    RDF::Enumerable#each_statement
     def each(&block)
-      @data.query(:context => context).each(&block)
+      @data.query({}).each(&block)
     end
 
     ##
     # @private
     # @see RDF::Queryable#query
     def query_pattern(pattern, &block)
-      pattern = pattern.dup
-      pattern.context = context
-      @data.query(pattern, &block)
+      @data.query(duplicate_statement(pattern), &block)
     end
 
     ##
     # @private
     # @see RDF::Mutable#insert
     def insert_statement(statement)
-      statement = statement.dup
-      statement.context = context
-      @data.insert(statement)
+      @data.insert(duplicate_statement(statement))
     end
 
     ##
     # @private
     # @see RDF::Mutable#delete
     def delete_statement(statement)
-      statement = statement.dup
-      statement.context = context
-      @data.delete(statement)
+      @data.delete(duplicate_statement(statement))
     end
 
     ##
@@ -227,11 +219,24 @@ module RDF
     def clear_statements
       @data.delete(:context => context)
     end
+    
+    ##
+    # @private
+    # Duplicates a statement, adding context of this graph if applicable.
+    #
+    # @param  [Statement] statement
+    # @return [Statement]
+    def duplicate_statement(statement)
+      statement = statement.dup
+      statement.context ||= context
+      statement
+    end
 
     protected :query_pattern
     protected :insert_statement
     protected :delete_statement
     protected :clear_statements
+    protected :duplicate_statement
 
     ##
     # @private

--- a/spec/model_graph_spec.rb
+++ b/spec/model_graph_spec.rb
@@ -17,4 +17,56 @@ describe RDF::Graph do
     graph.options.should have_key(:foo)
     graph.options[:foo].should == :bar
   end
+  
+  it "should not override context on statements without context" do
+    graph = @new.call
+    graph << RDF::Statement.new("s", "p", "o")
+    graph.first.context.should be_nil
+  end
+  
+  context "unnamed graphs" do
+    it "should not clear context on statements with context" do
+      graph = @new.call
+      graph << RDF::Statement.new("s", "p", "o", :context => "c")
+      graph.first.context.should == "c"
+    end
+    
+    it "should enumerate statements without context" do
+      graph = @new.call
+      graph << RDF::Statement.new("s", "p", "o")
+      graph.first.should_not be_nil
+    end
+    
+    it "should enumerate statements with context" do
+      graph = @new.call
+      graph << RDF::Statement.new("s", "p", "o", :context => "c")
+      graph.first.should_not be_nil
+    end
+  end
+  
+  context "named graphs" do
+    it "should override context on statements without context"  do
+      graph = @new.call("g")
+      graph << RDF::Statement.new("s", "p", "o")
+      graph.first.context.should == "g"
+    end
+    
+    it "should not override context on statements with context" do
+      graph = @new.call("g")
+      graph << RDF::Statement.new("s", "p", "o", :context => "c")
+      graph.first.context.should == "c"
+    end
+    
+    it "should enumerate statements without context" do
+      graph = @new.call("g")
+      graph << RDF::Statement.new("s", "p", "o")
+      graph.first.should_not be_nil
+    end
+
+    it "should enumerate statements with context" do
+      graph = @new.call("g")
+      graph << RDF::Statement.new("s", "p", "o", :context => "c")
+      graph.first.should_not be_nil
+    end
+  end
 end


### PR DESCRIPTION
Upon trying the "Moby Dick" example of the [N3 plugin](https://github.com/gkellogg/rdf-n3), I noticed that `Graph` discards context from added statements.
This creates the strange situation where adding

```
# Ora didn't write Moby Dick.
{ [ x:firstname  "Ora" ] dc:wrote [ dc:title  "Moby Dick" ] } a n3:falsehood .
```

to a graph, results in

```
# Ora wrote Moby Dick.
[ x:firstname  "Ora" ] dc:wrote [ dc:title  "Moby Dick" ].
# Lies exist.
_:g1 a n3:falsehood.
```

The above fragment contains exactly the **opposite** of what was intended.

This contribution:
- adds an **RSpec specification** of the desired behavior _(e.g. retaining context when applicable)_
- **fixes the problem** by not overwriting context if it is already present
- **fixes a related problem** where a graph would only enumerate nodes with its own context

Please comment if you have any questions or remarks.
