### PR TITLE
.to_sym and #to_sym for Format, Reader and Writer

### DIFF
--- a/lib/rdf/format.rb
+++ b/lib/rdf/format.rb
@@ -140,6 +140,16 @@ module RDF
     end
 
     ##
+    # Returns a symbol appropriate to use with RDF::Format.for()
+    # @return [Symbol]
+    def self.to_sym
+      elements = self.to_s.split("::")
+      sym = elements.pop
+      sym = elements.pop if sym == 'Format'
+      sym.downcase.to_s.to_sym
+    end
+
+    ##
     # Retrieves or defines the reader class for this RDF serialization
     # format.
     #

--- a/lib/rdf/reader.rb
+++ b/lib/rdf/reader.rb
@@ -128,6 +128,23 @@ module RDF
     end
 
     ##
+    # Returns a symbol appropriate to use with RDF::Reader.for()
+    # @return [Symbol]
+    def self.to_sym
+      elements = self.to_s.split("::")
+      sym = elements.pop
+      sym = elements.pop if sym == 'Reader'
+      sym.downcase.to_s.to_sym
+    end
+
+    ##
+    # Returns a symbol appropriate to use with RDF::Reader.for()
+    # @return [Symbol]
+    def to_sym
+      self.class.to_sym
+    end
+    
+    ##
     # Initializes the reader.
     #
     # @param  [IO, File, String] input

--- a/lib/rdf/writer.rb
+++ b/lib/rdf/writer.rb
@@ -159,6 +159,23 @@ module RDF
     end
 
     ##
+    # Returns a symbol appropriate to use with RDF::Writer.for()
+    # @return [Symbol]
+    def self.to_sym
+      elements = self.to_s.split("::")
+      sym = elements.pop
+      sym = elements.pop if sym == 'Writer'
+      sym.downcase.to_s.to_sym
+    end
+
+    ##
+    # Returns a symbol appropriate to use with RDF::Writer.for()
+    # @return [Symbol]
+    def to_sym
+      self.class.to_sym
+    end
+    
+    ##
     # Initializes the writer.
     #
     # @param  [IO, File] output

--- a/spec/nquads_spec.rb
+++ b/spec/nquads_spec.rb
@@ -23,6 +23,10 @@ describe RDF::NQuads::Format do
     ]
     formats.each { |format| format.should == RDF::NQuads::Format }
   end
+  
+  it "should return :nquads for to_sym" do
+    RDF::NQuads::Format.to_sym.should == :nquads
+  end
 end
 
 describe RDF::NQuads::Reader do
@@ -34,7 +38,6 @@ describe RDF::NQuads::Reader do
   # @see lib/rdf/spec/reader.rb in rdf-spec
   it_should_behave_like RDF_Reader
 
-
   it "should be discoverable" do
     readers = [
       RDF::Reader.for(:nquads),
@@ -44,6 +47,11 @@ describe RDF::NQuads::Reader do
       RDF::Reader.for(:content_type   => 'text/x-nquads'),
     ]
     readers.each { |reader| reader.should == RDF::NQuads::Reader }
+  end
+
+  it "should return :nquads for to_sym" do
+    @reader.class.to_sym.should == :nquads
+    @reader.to_sym.should == :nquads
   end
 end
 
@@ -59,5 +67,9 @@ describe RDF::NQuads::Writer do
       RDF::Writer.for(:content_type   => 'text/x-nquads'),
     ]
     writers.each { |writer| writer.should == RDF::NQuads::Writer }
+  end
+
+  it "should return :nquads for to_sym" do
+    RDF::NQuads::Writer.to_sym.should == :nquads
   end
 end

--- a/spec/ntriples_spec.rb
+++ b/spec/ntriples_spec.rb
@@ -22,6 +22,10 @@ describe RDF::NTriples::Format do
     ]
     formats.each { |format| format.should == RDF::NTriples::Format }
   end
+  
+  it "should return :ntriples for to_sym" do
+    RDF::NTriples::Format.to_sym.should == :ntriples
+  end
 end
 
 describe RDF::NTriples::Reader do
@@ -42,6 +46,11 @@ describe RDF::NTriples::Reader do
     ]
     readers.each { |reader| reader.should == RDF::NTriples::Reader }
   end
+
+  it "should return :ntriples for to_sym" do
+    @reader.class.to_sym.should == :ntriples
+    @reader.to_sym.should == :ntriples
+  end
 end
 
 describe RDF::NTriples::Writer do
@@ -54,6 +63,10 @@ describe RDF::NTriples::Writer do
       RDF::Writer.for(:content_type   => 'text/plain'),
     ]
     writers.each { |writer| writer.should == RDF::NTriples::Writer }
+  end
+
+  it "should return :ntriples for to_sym" do
+    RDF::NTriples::Writer.to_sym.should == :ntriples
   end
 end
 


### PR DESCRIPTION
.to_sym and #to_sym for Format, Reader and Writer, to retrieve a symbol appropriate for use with .for().

There are a number of different places where I need to retrieve an appropriate symbol for a given Format, Reader or Writer. It makes sense to put them here rather than repeat them for each gem.
