### PR TITLE
Fix doc for RDF::Literal::Integer#pred and #succ

### DIFF
--- a/lib/rdf/model/literal/integer.rb
+++ b/lib/rdf/model/literal/integer.rb
@@ -41,7 +41,7 @@ module RDF; class Literal
     end
 
     ##
-    # Returns the successor value of `self`.
+    # Returns the predecessor value of `self`.
     #
     # @return [RDF::Literal]
     # @since  0.2.3
@@ -50,7 +50,7 @@ module RDF; class Literal
     end
 
     ##
-    # Returns the predecessor value of `self`.
+    # Returns the successor value of `self`.
     #
     # @return [RDF::Literal]
     # @since  0.2.3


### PR DESCRIPTION
Small fix for a mix-up in the documentation for successor and predecessor.
