### PR TITLE
Reader parses values written prior to encoding

### DIFF
--- a/lib/rdf/reader.rb
+++ b/lib/rdf/reader.rb
@@ -488,7 +488,17 @@ module RDF
       @line = @line_rest || @input.readline
       @line, @line_rest = @line.split("\r", 2)
       @line = @line.to_s.chomp
-      @line.encode!(encoding) if @line.respond_to?(:encode!)
+      begin
+        @line.encode!(encoding) if @line.respond_to?(:encode!)
+      rescue Encoding::UndefinedConversionError, Encoding::InvalidByteSequenceError, Encoding::ConverterNotFoundError
+        # It is likely the persisted line was not encoded on initial write
+        # (i.e. persisted via RDF <= 1.0.9 and read via RDF >= 1.0.10)
+        #
+        # Encoding::UndefinedConversionError is raised by MRI.
+        # Encoding::InvalidByteSequenceError is raised by jruby >= 1.7.5
+        # Encoding::ConverterNotFoundError is raised by jruby < 1.7.5
+        @line = RDF::NTriples::Reader.unescape(@line).encode!(encoding)
+      end
       @line
     end
 

--- a/spec/ntriples_spec.rb
+++ b/spec/ntriples_spec.rb
@@ -502,6 +502,16 @@ describe RDF::NTriples do
         end
       end
 
+      it 'should parse a value that was written without passing through the writer encoding' do
+        nt = "<http://subj> <http://pred> \"Procreation Metaphors in S\xC3\xA9an \xC3\x93 R\xC3\xADord\xC3\xA1in's Poetry\" .".force_encoding("ASCII-8BIT")
+        if defined?(::Encoding)
+          statement = @reader.unserialize(nt)
+          expect(statement.object.value).to eq("Procreation Metaphors in Séan Ó Ríordáin's Poetry")
+        else
+          pending("Not supported on Ruby 1.8")
+        end
+      end
+
       it "should parse long literal with escape" do
         nt = %(<http://subj> <http://pred> "\\U00015678another" .)
         if defined?(::Encoding)


### PR DESCRIPTION
With the addition of setting encoding on write (yay!), it is possible
that existing persisted statements were written without encoding. When
attempting to read those previously written statements, the reader
raises an Encoding::UndefinedConversionError.

By catching that error and sending it through the unescape sequence,
it is possible to apply the unescape/encoding correct behavior.

Should the RDF::NTriples::Reader.unescape method be extracted as a
service method on RDF? Given that this pull request is setting up a
case where the Ancestor class is calling a method on a Descendant
class.

This appears to be an issue when moving from 1.0.9 to 1.0.10

https://github.com/ruby-rdf/rdf/compare/1.0.9...1.0.10, in particular
https://github.com/ruby-rdf/rdf/compare/1.0.9...1.0.10#diff-94c44c6c4ab4c6e92f428841d0e827c3L60
