### PR TITLE
list properties/classes of strict vocabularies

### DIFF
--- a/lib/rdf/vocab.rb
+++ b/lib/rdf/vocab.rb
@@ -87,7 +87,7 @@ module RDF
       # @overload property(name, options)
       #   Defines a new property or class in the vocabulary.
       #   Optional labels and comments are stripped of unnecessary whitespace.
-      # 
+      #
       #   @param [String, #to_s] name
       #   @param [Hash{Symbol => Object}] options
       #   @option options [String, #to_s] :label
@@ -281,7 +281,7 @@ module RDF
       # @overload property(name, options)
       #   Defines a new property or class in the vocabulary.
       #   Optional labels and comments are stripped of unnecessary whitespace.
-      # 
+      #
       #   @param [String, #to_s] name
       #   @param [Hash{Symbol => Object}] options
       #   @option options [String, #to_s] :label
@@ -299,6 +299,12 @@ module RDF
           @@comments[prop] = options[:comment].to_s.strip.gsub(/\s+/m, ' ') if options[:comment]
           (class << self; self; end).send(:define_method, name) { prop } unless name.to_s == "property"
         end
+      end
+
+      ##
+      #  @return [Array<RDF::URI>] a list of properties in the current vocabulary
+      def properties
+        @@properties.keys
       end
 
       def [](name)

--- a/spec/vocab_strict_spec.rb
+++ b/spec/vocab_strict_spec.rb
@@ -27,6 +27,10 @@ describe RDF::StrictVocabulary do
     test_vocab["prop2"].should be_a(RDF::URI)
   end
 
+  it "should list properties that have been defined" do
+    expect([test_vocab.prop, test_vocab.Class, test_vocab.prop2] - test_vocab.properties).to be_empty
+  end
+
   it "should not respond to [] with properties that have not been defined" do
     expect{ test_vocab["not_a_prop"] }.to raise_error(KeyError)
     expect{ test_vocab[:not_a_prop] }.to raise_error(KeyError)


### PR DESCRIPTION
I need to be able to access a list of allowable terms within a StrictVocabulary (I'm creating drop down menus).  This change is just a way to get the registered URIs in a list.

My use case really only requires this method on StrictVocabs, but I also considered moving @@properties up to Vocabulary so this could apply to registered terms in general. I'm open to making that change if it's deemed appropriate.
