### PR TITLE
RDF::URI#label #comment for Vocabulary entries

### DIFF
--- a/lib/rdf.rb
+++ b/lib/rdf.rb
@@ -220,6 +220,46 @@ module RDF
     RDF::URI.intern("http://www.w3.org/1999/02/22-rdf-syntax-ns#")
   end
 
+  private
+
+  @@labels = {}
+  @@comments = {}
+
+  public
+
+  class << self
+
+    ##
+    # Find the label for an RDF term
+    #
+    # @param [Symbol] the name of a property
+    # @return [String] the label of that property
+    def label_for(term)
+      term_uri = self[term.to_sym]
+      @@labels.fetch(term_uri) { '' }
+    end
+
+    ##
+    # Find the comment for an RDF term
+    #
+    # @param [Symbol] the name of a property
+    # @return [String] the comment of that property
+    def comment_for(term)
+      term_uri = self[term.to_sym]
+      @@comments.fetch(term_uri) { '' }
+    end
+
+    ##
+    # Only capitalize first letter
+    # (default capitalize will lower_case later Camel cased upper case letters)
+    #
+    # @param [String] the term
+    # @return [String] term with first letter upcases
+    def capitalize_first_letter_only(term)
+      term.sub(/\A(.)/) { |l| l.upcase }
+    end
+  end
+
   # RDF Vocabulary terms
   %w(
     Alt
@@ -241,6 +281,8 @@ module RDF
     term_uri = self[term.to_sym]
     define_method(term) {term_uri}
     module_function term.to_sym
+    @@labels[term_uri] = capitalize_first_letter_only(term)
+    @@comments[term_uri] = "A #{term}."
   end
 
   class << self

--- a/lib/rdf/model/uri.rb
+++ b/lib/rdf/model/uri.rb
@@ -797,6 +797,28 @@ module RDF
     end
 
     ##
+    # Find the label for a vocabulary entry
+    #
+    # @return [String] the label of that property
+    def label
+      prefix, name = qname
+      raise 'RDF::URI#label only defined for Vocabulary entries.' unless prefix
+      vocab = RDF::Vocabulary.by_prefix(prefix)
+      vocab.label_for(name)
+    end
+
+    ##
+    # Find the comment for a vocabulary entry
+    #
+    # @return [String] the name of the entry
+    def comment
+      prefix, name = qname
+      raise 'RDF::URI#comment only defined for Vocabulary entries.' unless prefix
+      vocab = RDF::Vocabulary.by_prefix(prefix)
+      vocab.comment_for(name)
+    end
+
+    ##
     # lexical representation of URI, either absolute or relative
     # @return [String] 
     def value

--- a/lib/rdf/vocab.rb
+++ b/lib/rdf/vocab.rb
@@ -153,6 +153,12 @@ module RDF
         end
       end
 
+      ##
+      # Returns the class based on the prefix
+      def by_prefix(prefix)
+        RDF.const_get(prefix.to_s.upcase)
+      end
+
       # Preserve the class name so that it can be obtained even for
       # vocabularies that define a `name` property:
       alias_method :__name__, :name

--- a/spec/model_uri_spec.rb
+++ b/spec/model_uri_spec.rb
@@ -699,4 +699,115 @@ describe RDF::URI do
   context "Examples" do
     it "needs specs for documentation examples"
   end
+
+  context "Vocab" do
+    context "URI is NOT a vocab entry" do
+
+      let(:rdf_uri) { described_class.new }
+
+      it '#label raises RuntimeError' do
+        expect{ rdf_uri.label }.to raise_error(
+          RuntimeError,
+          'RDF::URI#label only defined for Vocabulary entries.'
+        )
+      end
+
+      it '#comment raises RuntimeError' do
+        expect{ rdf_uri.comment }.to raise_error(
+          RuntimeError,
+          'RDF::URI#comment only defined for Vocabulary entries.'
+        )
+      end
+    end
+
+    context "URI is a vocab entry" do
+      context "RDF::TEST" do
+
+        let(:test_vocab) do
+          RDF::TEST = Class.new(RDF::StrictVocabulary.create("http://example.com/test#")) do
+            property :Class
+            property :prop
+            property :prop2, :label => "Test property label", :comment => " Test property comment"
+            property :Person, :label => 'RDF::TEST Person', :comment => "An RDF::TEST person."
+          end
+        end
+
+        let(:vocab_entry) do
+          test_vocab.properties.detect{ |p| p.qname == [:test, :prop2] }
+        end
+
+        after do
+          RDF.send(:remove_const, :TEST)
+        end
+
+        it '#label' do
+          expect(vocab_entry.label).to eq "Test property label"
+        end
+
+        it '#comment' do
+          expect(vocab_entry.comment).to eq "Test property comment"
+        end
+
+        context 'also a test:Person entry here, different from foaf:Person' do
+
+          let(:test_person_entry) do
+            test_vocab.properties.detect{ |p| p.qname == [:test, :Person] }
+          end
+
+          it '#label' do
+            expect(test_person_entry.label).to eq "RDF::TEST Person"
+          end
+
+          it '#comment' do
+            expect(test_person_entry.comment).to eq "An RDF::TEST person."
+          end
+        end
+      end
+
+      context "RDF::FOAF" do
+
+        let(:vocab_entry) do
+          RDF::FOAF.properties.detect{ |p| p.qname == [:foaf, :Person] }
+        end
+
+        it '#label' do
+          expect(vocab_entry.label).to eq "Person"
+        end
+
+        it '#comment' do
+          expect(vocab_entry.comment).to eq "A person."
+        end
+      end
+
+      context "RDF.type" do
+
+        let(:vocab_entry) do
+          RDF.type
+        end
+
+        it '#label' do
+          expect(vocab_entry.label).to eq "Type"
+        end
+
+        it '#comment' do
+          expect(vocab_entry.comment).to eq "A type."
+        end
+      end
+
+      context "RDF.type" do
+
+        let(:vocab_entry) do
+          RDF.langString
+        end
+
+        it '#label' do
+          expect(vocab_entry.label).to eq "LangString"
+        end
+
+        it '#comment' do
+          expect(vocab_entry.comment).to eq "A langString."
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Based on the feature request https://github.com/ruby-rdf/rdf/issues/156
(and my own needs), I implemented a first version of #label and #comment
on a Vocabulary entry.

Open for critique, I can try to improve it if needed :-)
- Vocabulary entries
- also RDF properties (temporary comment and label definitions)
- raise error when called on RDF::URI that are not vocabulary entries
