### PR TITLE
Simplify ntriples unescape

### DIFF
--- a/lib/rdf/ntriples/reader.rb
+++ b/lib/rdf/ntriples/reader.rb
@@ -164,18 +164,6 @@ module RDF::NTriples
       # Decode \t|\n|\r|\"|\\ character escapes:
       ESCAPE_CHARS.each { |escape| string.gsub!(escape.inspect[1...-1], escape) }
 
-      # Decode \uXXXX\uXXXX surrogate pairs:
-      while
-        (string.sub!(ESCAPE_SURROGATE) do
-          if ESCAPE_SURROGATE1.include?($1.hex) && ESCAPE_SURROGATE2.include?($2.hex)
-            s = [$1, $2].pack('H*H*')
-            s.force_encoding(Encoding::UTF_16BE).encode!(Encoding::UTF_8)
-          else
-            [$1.hex].pack('U*') << '\u' << $2
-          end
-        end)
-      end
-
       # Decode \uXXXX and \UXXXXXXXX code points:
       string.gsub!(ESCAPE_CHAR) do
         [($1 || $2).hex].pack('U*')


### PR DESCRIPTION
While trying to understand the unescape function of the ntriples reader, I found a few potential simplifications. Would it be possible to take a look at this to see if I am missing something?
