### PR TITLE
Add RDF::Util::File.http_adapter to support pluggable HTTP clients

### DIFF
--- a/lib/rdf/util/file.rb
+++ b/lib/rdf/util/file.rb
@@ -4,19 +4,210 @@ require 'time'
 
 module RDF; module Util
   ##
-  # Wrapper for Net::HTTP. This allows implementations to override
-  # for more sophisticated behavior.
-  #
+  # Wrapper for retrieving RDF resources from HTTP(S) and file: scheme locations.
+  # 
+  # By default, HTTP(S) resources are retrieved using Net::HTTP. However, 
   # If the [Rest Client](https://rubygems.org/gems/rest-client) gem is included,
-  # it will be used for retrieving resources allowing for
+  # it will be used for retrieving resources, allowing for
   # sophisticated HTTP caching using [REST Client Components](https://rubygems.org/gems/rest-client-components)
   # allowing the use of `Rack::Cache` to avoid network access.
+  #
+  # To use other HTTP clients, consumers can subclass 
+  # {RDF::Util::File::HttpAdapter} and set the {RDF::Util::File.http_adapter}.
   #
   # Also supports the file: scheme for access to local files.
   #
   #
   # @since 0.2.4
   module File
+
+    ##
+    # @abstract Subclass and override {.open_url} to implement a custom adapter
+    # @since 1.2
+    class HttpAdapter
+      ##
+      # @param  [Hash{Symbol => Object}] options
+      # @option options [Array, String] :headers
+      #   HTTP Request headers
+      # @return [Hash] A hash of HTTP request headers
+      def self.headers options
+        headers = options.fetch(:headers, {})
+        headers['Accept'] ||= default_accept_header
+        headers
+      end
+
+      ##
+      # @return [String] the value for an Accept header
+      def self.default_accept_header
+        # Receive text/html and text/plain at a lower priority than other formats
+        reader_types = RDF::Format.reader_types.map do |t|
+          t.to_s =~ /text\/(?:plain|html)/  ? "#{t};q=0.5" : t
+        end
+
+        (reader_types + %w(*/*;q=0.1)).join(", ")
+      end
+      
+      ##
+      # @abstract
+      # @param [String] base_uri to open
+      # @param  [Hash{Symbol => Object}] options
+      #   options are ignored in this implementation. Applications are encouraged
+      #   to override this implementation to provide more control over HTTP
+      #   headers and redirect following.
+      # @option options [String] :proxy
+      #   HTTP Proxy to use for requests.
+      # @option options [Array, String] :headers
+      #   HTTP Request headers
+      # @option options [Boolean] :verify_none (false)
+      #   Don't verify SSL certificates
+      # @return [RemoteDocument, Object] A {RemoteDocument}. If a block is given, the result of evaluating the block is returned.
+      def self.open_url base_uri, options
+        raise NoMethodError.new("#{self.inspect} does not implement required method `open_url` for ", "open_url")
+      end
+    end
+
+    ##
+    # If the [Rest Client](https://rubygems.org/gems/rest-client) gem is included,
+    # it will be used for retrieving resources allowing for
+    # sophisticated HTTP caching using [REST Client Components](https://rubygems.org/gems/rest-client-components)
+    # allowing the use of `Rack::Cache` to avoid network access.
+    # @since 1.2
+    class RestClientAdapter < HttpAdapter
+      # @see HttpAdapter.open_url
+      # @param [String] base_uri to open
+      # @param  [Hash{Symbol => Object}] options
+      # @return [RemoteDocument, Object] A {RemoteDocument}. If a block is given, the result of evaluating the block is returned.
+      def self.open_url base_uri, options
+        ssl_verify = options[:verify_none] ? OpenSSL::SSL::VERIFY_NONE : OpenSSL::SSL::VERIFY_PEER
+
+        # If RestClient is loaded, prefer it
+        RestClient.proxy = options[:proxy].to_s if options[:proxy]
+        client = RestClient::Resource.new(base_uri, verify_ssl: ssl_verify)
+        client.get(headers(options)) do |response, request, res, &blk|
+          case response.code
+          when 200..299
+            # found object
+
+            # If a Location is returned, it defines the base resource for this file, not it's actual ending location
+            document_options = {
+              base_uri:     RDF::URI(response.headers.fetch(:location, base_uri)),
+              charset:      Encoding::UTF_8,
+              code:         response.code.to_i,
+              headers:      response.headers
+            }
+
+            remote_document = RemoteDocument.new(response.body, document_options)
+          when 300..399
+            # Document base is redirected location
+            base_uri = response.headers[:location].to_s
+            response.follow_redirection(request, res, &blk)
+          else
+            raise IOError, "<#{base_uri}>: #{response.code}"
+          end
+        end
+      end
+    end
+
+    ##
+    # Net::HTTP adapter to retrieve resources without additional dependencies
+    # @since 1.2
+    class NetHttpAdapter < HttpAdapter
+      # @see HttpAdapter.open_url
+      # @param [String] base_uri to open
+      # @param  [Hash{Symbol => Object}] options
+      # @return [RemoteDocument, Object] A {RemoteDocument}. If a block is given, the result of evaluating the block is returned.
+      def self.open_url base_uri, options
+        ssl_verify = options[:verify_none] ? OpenSSL::SSL::VERIFY_NONE : OpenSSL::SSL::VERIFY_PEER
+
+        redirect_count = 0
+        max_redirects = 5
+        parsed_url = ::URI.parse(base_uri)
+        parsed_proxy = ::URI.parse(options[:proxy].to_s)
+        base_uri = parsed_url.to_s
+        remote_document = nil
+
+        until remote_document do
+          Net::HTTP::start(parsed_url.host, parsed_url.port,
+                          parsed_proxy.host, parsed_proxy.port,
+                          open_timeout: 60 * 1000,
+                          use_ssl: parsed_url.scheme == 'https',
+                          verify_mode: ssl_verify
+          ) do |http|
+            request = Net::HTTP::Get.new(parsed_url.request_uri, headers(options))
+            http.request(request) do |response|
+              case response
+              when Net::HTTPSuccess
+                # found object
+
+                # Normalize headers using symbols
+                response_headers = response.to_hash.inject({}) do |out, (key, value)|
+                  out[key.gsub(/-/, '_').downcase.to_sym] = %w{ set-cookie }.include?(key.downcase) ? value : value.first
+                  out
+                end
+
+                # If a Location is returned, it defines the base resource for this file, not it's actual ending location
+                document_options = {
+                  base_uri:     RDF::URI(response["Location"] ? response["Location"] : base_uri),
+                  charset:      Encoding::UTF_8,
+                  code:         response.code.to_i,
+                  content_type: response.content_type,
+                  headers:      response_headers
+                }.merge(response.type_params)
+                document_options[:last_modified] = DateTime.parse(response["Last-Modified"]) if response["Last-Modified"]
+
+                remote_document = RemoteDocument.new(response.body, document_options)
+              when Net::HTTPRedirection
+                # Follow redirection
+                raise IOError, "Too many redirects" if (redirect_count += 1) > max_redirects
+
+                parsed_url = ::URI.parse(response["Location"])
+
+                base_uri = parsed_url.to_s
+              else
+                raise IOError, "<#{parsed_url}>: #{response.message}(#{response.code})"
+              end
+            end
+          end
+        end
+        remote_document
+      end
+    end
+
+    class <<self
+      ##
+      # Set the HTTP adapter
+      # @see .http_adapter
+      # @param [HttpAdapter] http_adapter
+      # @return [HttpAdapter]
+      # @since 1.2
+      def http_adapter= http_adapter
+        @http_adapter = http_adapter
+      end
+
+      ##
+      # Get current HTTP adapter. If no adapter has been explicitly set,
+      # use RestClientAdapter (if RestClient is loaded), or the NetHttpAdapter
+      #
+      # @param [Boolean] use_net_http use the NetHttpAdapter, even if other
+      #      adapters have been configured
+      # @return [HttpAdapter]
+      # @since 1.2
+      def http_adapter use_net_http = false
+        if use_net_http
+          NetHttpAdapter
+        else
+          @http_adapter ||= begin
+            # Otherwise, fallback to Net::HTTP
+            if defined?(RestClient)
+              RestClientAdapter
+            else
+              NetHttpAdapter
+            end
+          end
+        end
+      end
+    end
+
     ##
     # Open the file, returning or yielding {RemoteDocument}.
     #
@@ -59,94 +250,9 @@ module RDF; module Util
       remote_document = nil
 
       if filename_or_url.to_s =~ /^https?/
-        # Open as a URL with Net::HTTP
-        headers = options.fetch(:headers, {})
-        # Receive text/html and text/plain at a lower priority than other formats
-        reader_types = RDF::Format.reader_types.map do |t|
-          t.to_s =~ /text\/(?:plain|html)/  ? "#{t};q=0.5" : t
-        end
-        headers['Accept'] ||= (reader_types + %w(*/*;q=0.1)).join(", ")
-
         base_uri = filename_or_url.to_s
-        ssl_verify = options[:verify_none] ? OpenSSL::SSL::VERIFY_NONE : OpenSSL::SSL::VERIFY_PEER
 
-        if defined?(RestClient) && !options[:use_net_http]
-          # If RestClient is loaded, prefer it
-          RestClient.proxy = options[:proxy].to_s if options[:proxy]
-          client = RestClient::Resource.new(base_uri, verify_ssl: ssl_verify)
-          client.get(headers) do |response, request, res, &blk|
-            case response.code
-            when 200..299
-              # found object
-
-              # If a Location is returned, it defines the base resource for this file, not it's actual ending location
-              document_options = {
-                base_uri:     RDF::URI(response.headers.fetch(:location, base_uri)),
-                charset:      Encoding::UTF_8,
-                code:         response.code.to_i,
-                headers:      response.headers
-              }
-
-              remote_document = RemoteDocument.new(response.body, document_options)
-            when 300..399
-              # Document base is redirected location
-              base_uri = response.headers[:location].to_s
-              response.follow_redirection(request, res, &blk)
-            else
-              raise IOError, "<#{base_uri}>: #{response.code}"
-            end
-          end
-        else
-          # Otherwise, fallback to Net::HTTP
-          redirect_count = 0
-          max_redirects = 5
-          parsed_url = ::URI.parse(filename_or_url.to_s)
-          parsed_proxy = ::URI.parse(options[:proxy].to_s)
-          base_uri = parsed_url.to_s
-          until remote_document do
-            Net::HTTP::start(parsed_url.host, parsed_url.port,
-                            parsed_proxy.host, parsed_proxy.port,
-                            open_timeout: 60 * 1000,
-                            use_ssl: parsed_url.scheme == 'https',
-                            verify_mode: ssl_verify
-            ) do |http|
-              request = Net::HTTP::Get.new(parsed_url.request_uri, headers)
-              http.request(request) do |response|
-                case response
-                when Net::HTTPSuccess
-                  # found object
-
-                  # Normalize headers using symbols
-                  response_headers = response.to_hash.inject({}) do |out, (key, value)|
-                    out[key.gsub(/-/, '_').downcase.to_sym] = %w{ set-cookie }.include?(key.downcase) ? value : value.first
-                    out
-                  end
-
-                  # If a Location is returned, it defines the base resource for this file, not it's actual ending location
-                  document_options = {
-                    base_uri:     RDF::URI(response["Location"] ? response["Location"] : base_uri),
-                    charset:      Encoding::UTF_8,
-                    code:         response.code.to_i,
-                    content_type: response.content_type,
-                    headers:      response_headers
-                  }.merge(response.type_params)
-                  document_options[:last_modified] = DateTime.parse(response["Last-Modified"]) if response["Last-Modified"]
-
-                  remote_document = RemoteDocument.new(response.body, document_options)
-                when Net::HTTPRedirection
-                  # Follow redirection
-                  raise IOError, "Too many redirects" if (redirect_count += 1) > max_redirects
-
-                  parsed_url = ::URI.parse(response["Location"])
-
-                  base_uri = parsed_url.to_s
-                else
-                  raise IOError, "<#{parsed_url}>: #{response.message}(#{response.code})"
-                end
-              end
-            end
-          end
-        end
+        remote_document = self.http_adapter(!!options[:use_net_http]).open_url(base_uri, options)
       else
         # Fake content type based on found format
         format = RDF::Format.for(filename_or_url.to_s)

--- a/spec/util_file_spec.rb
+++ b/spec/util_file_spec.rb
@@ -3,13 +3,34 @@ require 'webmock/rspec'
 require 'rdf/ntriples'
 
 describe RDF::Util::File do
-  let(:uri) {"http://ruby-rdf.github.com/rdf/etc/doap.nt"}
-  let(:opened) {double("opened")}
-  before(:each) do
-    expect(opened).to receive(:opened)
+  describe ".http_adapter" do
+    after do
+      RDF::Util::File.http_adapter = nil
+    end
+
+    it "returns Net::HTTP if rest-client is not available" do
+      hide_const("RestClient")
+      expect(RDF::Util::File.http_adapter).to eq RDF::Util::File::NetHttpAdapter
+    end
+    
+    it "returns RestClient if rest-client is available" do
+      require 'rest-client'
+      expect(RDF::Util::File.http_adapter).to eq RDF::Util::File::RestClientAdapter
+    end
+    
+    it "return Net::HTTP if explicitly requested" do
+      require 'rest-client'
+      expect(RDF::Util::File.http_adapter(true)).to eq RDF::Util::File::NetHttpAdapter
+    end
   end
 
   describe ".open_file" do
+    let(:uri) {"http://ruby-rdf.github.com/rdf/etc/doap.nt"}
+    let(:opened) {double("opened")}
+    before(:each) do
+      expect(opened).to receive(:opened)
+    end
+
     it "yields a local file" do
       r = RDF::Util::File.open_file(fixture_path("test.nt")) do |f|
         expect(f).to respond_to(:read)
@@ -56,163 +77,169 @@ describe RDF::Util::File do
     end
 
     context "HTTP(s)" do
-      [true, false].each do |with_net_http|
-        require 'rest-client' unless with_net_http
-        context with_net_http ? "using NET::HTTP" : "using RestClient" do
-          it "returns an http URL" do
+
+      shared_context "using a HTTP client" do
+        before do
+          RDF::Util::File.http_adapter = http_adapter
+        end
+
+        after do
+          RDF::Util::File.http_adapter = nil
+        end
+
+        it "returns an http URL" do
+          WebMock.stub_request(:get, uri).
+            to_return(body: File.read(File.expand_path("../../etc/doap.nt", __FILE__)),
+                      status: 200,
+                      headers: { 'Content-Type' => RDF::NTriples::Format.content_type.first})
+          f = RDF::Util::File.open_file(uri)
+          expect(f).to respond_to(:read)
+          expect(f.content_type).to eq RDF::NTriples::Format.content_type.first
+          expect(f.code).to eq 200
+          opened.opened
+        end
+
+        it "adds Accept header using defined readers" do
+          content_types = RDF::Reader.map {|r| r.format.content_type}.flatten.uniq
+          WebMock.stub_request(:get, uri).with do |request|
+            expect(request.headers['Accept']).to include(*content_types)
+          end.to_return(body: "foo")
+          RDF::Util::File.open_file(uri) do |f|
+            opened.opened
+          end
+        end
+
+        it "adds Accept header with low-priority */*" do
+          WebMock.stub_request(:get, uri).with do |request|
+            expect(request.headers['Accept']).to include('*/*;q=0.1')
+          end.to_return(body: "foo")
+          RDF::Util::File.open_file(uri) do |f|
+            opened.opened
+          end
+        end
+
+        it "used provided Accept header" do
+          WebMock.stub_request(:get, uri).with do |request|
+            expect(request.headers["Accept"]).to include('a/b')
+          end.to_return(body: "foo")
+          RDF::Util::File.open_file(uri, headers: {"Accept" => "a/b"}) do |f|
+            opened.opened
+          end
+        end
+
+        it "sets content_type and encoding to utf-8 if absent" do
+          WebMock.stub_request(:get, uri).to_return(body: "foo", headers: {"Content-Type" => "text/turtle"})
+          RDF::Util::File.open_file(uri) do |f|
+            expect(f.content_type).to eq "text/turtle"
+            expect(f.charset).to eq Encoding::UTF_8
+            expect(f.content_encoding).to eq "utf-8"
+            expect(f.external_encoding.to_s.downcase).to eq "utf-8"
+            opened.opened
+          end
+        end
+
+        it "sets content_type and encoding if provided" do
+          WebMock.stub_request(:get, uri).to_return(body: "foo", headers: {"Content-Type" => "text/turtle ; charset=ISO-8859-4"})
+          RDF::Util::File.open_file(uri) do |f|
+            expect(f.content_type).to eq "text/turtle"
+            expect(f.charset).to eq "ISO-8859-4"
+            expect(f.external_encoding.to_s.downcase).to eq "iso-8859-4"
+            opened.opened
+          end
+        end
+
+        it "sets last_modified if provided" do
+          WebMock.stub_request(:get, uri).to_return(body: "foo", headers: {"Last-Modified" => "Thu, 24 Oct 2013 23:46:56 GMT"})
+          RDF::Util::File.open_file(uri) do |f|
+            expect(f.last_modified).to eq DateTime.parse("Thu, 24 Oct 2013 23:46:56 GMT")
+            opened.opened
+          end
+        end
+
+        it "sets etag if provided" do
+          WebMock.stub_request(:get, uri).to_return(body: "foo", headers: {"ETag" => "abc123"})
+          RDF::Util::File.open_file(uri) do |f|
+            expect(f.etag).to eq "abc123"
+            opened.opened
+          end
+        end
+
+        it "sets arbitrary header" do
+          WebMock.stub_request(:get, uri).to_return(body: "foo", headers: {"Foo" => "Bar"})
+          RDF::Util::File.open_file(uri) do |f|
+            expect(f.headers).to include(:foo => %(Bar))
+            opened.opened
+          end
+        end
+
+        context "redirects" do
+          it "sets base_uri to resource" do
+            WebMock.stub_request(:get, uri).to_return(body: "foo")
+            RDF::Util::File.open_file(uri) do |f|
+              expect(f.base_uri).to eq uri
+              opened.opened
+            end
+          end
+
+          it "sets base_uri to location if present" do
+            WebMock.stub_request(:get, uri).to_return(body: "foo", headers: {"Location" => "http://example/"})
+            RDF::Util::File.open_file(uri) do |f|
+              expect(f.base_uri).to eq "http://example/"
+              opened.opened
+            end
+          end
+
+          it "follows 301 and uses new location" do
+            WebMock.stub_request(:get, uri).to_return({status: 301, headers: {"Location" => "http://example/"}})
+            WebMock.stub_request(:get, "http://example/").to_return({body: "foo"})
+            RDF::Util::File.open_file(uri) do |f|
+              expect(f.base_uri).to eq "http://example/"
+              expect(f.read).to eq "foo"
+              opened.opened
+            end
+          end
+
+          it "follows 302 and uses new location" do
+            WebMock.stub_request(:get, uri).to_return({status: 302, headers: {"Location" => "http://example/"}})
+            WebMock.stub_request(:get, "http://example/").to_return({body: "foo"})
+            RDF::Util::File.open_file(uri) do |f|
+              expect(f.base_uri).to eq "http://example/"
+              expect(f.read).to eq "foo"
+              opened.opened
+            end
+          end
+
+          it "follows 303 and uses new location" do
+            WebMock.stub_request(:get, uri).to_return({status: 303, headers: {"Location" => "http://example/"}})
+            WebMock.stub_request(:get, "http://example/").to_return({body: "foo"})
+            RDF::Util::File.open_file(uri) do |f|
+              expect(f.base_uri).to eq "http://example/"
+              expect(f.read).to eq "foo"
+              opened.opened
+            end
+          end
+
+          it "follows 307 and uses new location" do
+            WebMock.stub_request(:get, uri).to_return({status: 307, headers: {"Location" => "http://example/"}})
+            WebMock.stub_request(:get, "http://example/").to_return({body: "foo"})
+            RDF::Util::File.open_file(uri) do |f|
+              expect(f.base_uri).to eq "http://example/"
+              expect(f.read).to eq "foo"
+              opened.opened
+            end
+          end
+        end
+
+        context "proxy" do
+          it "requests through proxy" do
             WebMock.stub_request(:get, uri).
               to_return(body: File.read(File.expand_path("../../etc/doap.nt", __FILE__)),
                         status: 200,
                         headers: { 'Content-Type' => RDF::NTriples::Format.content_type.first})
-            f = RDF::Util::File.open_file(uri, use_net_http: with_net_http)
-            expect(f).to respond_to(:read)
-            expect(f.content_type).to eq RDF::NTriples::Format.content_type.first
-            expect(f.code).to eq 200
-            opened.opened
-          end
-
-          it "adds Accept header using defined readers" do
-            content_types = RDF::Reader.map {|r| r.format.content_type}.flatten.uniq
-            WebMock.stub_request(:get, uri).with do |request|
-              expect(request.headers['Accept']).to include(*content_types)
-            end.to_return(body: "foo")
-            RDF::Util::File.open_file(uri, use_net_http: with_net_http) do |f|
+            RDF::Util::File.open_file(uri, proxy: "http://proxy.example.com") do |f|
               opened.opened
             end
-          end
-
-          it "adds Accept header with low-priority */*" do
-            WebMock.stub_request(:get, uri).with do |request|
-              expect(request.headers['Accept']).to include('*/*;q=0.1')
-            end.to_return(body: "foo")
-            RDF::Util::File.open_file(uri, use_net_http: with_net_http) do |f|
-              opened.opened
-            end
-          end
-
-          it "used provided Accept header" do
-            WebMock.stub_request(:get, uri).with do |request|
-              expect(request.headers["Accept"]).to include('a/b')
-            end.to_return(body: "foo")
-            RDF::Util::File.open_file(uri, headers: {"Accept" => "a/b"}, use_net_http: with_net_http) do |f|
-              opened.opened
-            end
-          end
-
-          it "sets content_type and encoding to utf-8 if absent" do
-            WebMock.stub_request(:get, uri).to_return(body: "foo", headers: {"Content-Type" => "text/turtle"})
-            RDF::Util::File.open_file(uri, use_net_http: with_net_http) do |f|
-              expect(f.content_type).to eq "text/turtle"
-              expect(f.charset).to eq Encoding::UTF_8
-              expect(f.content_encoding).to eq "utf-8"
-              expect(f.external_encoding.to_s.downcase).to eq "utf-8"
-              opened.opened
-            end
-          end
-
-          it "sets content_type and encoding if provided" do
-            WebMock.stub_request(:get, uri).to_return(body: "foo", headers: {"Content-Type" => "text/turtle ; charset=ISO-8859-4"})
-            RDF::Util::File.open_file(uri, use_net_http: with_net_http) do |f|
-              expect(f.content_type).to eq "text/turtle"
-              expect(f.charset).to eq "ISO-8859-4"
-              expect(f.external_encoding.to_s.downcase).to eq "iso-8859-4"
-              opened.opened
-            end
-          end
-
-          it "sets last_modified if provided" do
-            WebMock.stub_request(:get, uri).to_return(body: "foo", headers: {"Last-Modified" => "Thu, 24 Oct 2013 23:46:56 GMT"})
-            RDF::Util::File.open_file(uri, use_net_http: with_net_http) do |f|
-              expect(f.last_modified).to eq DateTime.parse("Thu, 24 Oct 2013 23:46:56 GMT")
-              opened.opened
-            end
-          end
-
-          it "sets etag if provided" do
-            WebMock.stub_request(:get, uri).to_return(body: "foo", headers: {"ETag" => "abc123"})
-            RDF::Util::File.open_file(uri, use_net_http: with_net_http) do |f|
-              expect(f.etag).to eq "abc123"
-              opened.opened
-            end
-          end
-
-          it "sets arbitrary header" do
-            WebMock.stub_request(:get, uri).to_return(body: "foo", headers: {"Foo" => "Bar"})
-            RDF::Util::File.open_file(uri, use_net_http: with_net_http) do |f|
-              expect(f.headers).to include(:foo => %(Bar))
-              opened.opened
-            end
-          end
-
-          context "redirects" do
-            it "sets base_uri to resource" do
-              WebMock.stub_request(:get, uri).to_return(body: "foo")
-              RDF::Util::File.open_file(uri, use_net_http: with_net_http) do |f|
-                expect(f.base_uri).to eq uri
-                opened.opened
-              end
-            end
-
-            it "sets base_uri to location if present" do
-              WebMock.stub_request(:get, uri).to_return(body: "foo", headers: {"Location" => "http://example/"})
-              RDF::Util::File.open_file(uri, use_net_http: with_net_http) do |f|
-                expect(f.base_uri).to eq "http://example/"
-                opened.opened
-              end
-            end
-
-            it "follows 301 and uses new location" do
-              WebMock.stub_request(:get, uri).to_return({status: 301, headers: {"Location" => "http://example/"}})
-              WebMock.stub_request(:get, "http://example/").to_return({body: "foo"})
-              RDF::Util::File.open_file(uri, use_net_http: with_net_http) do |f|
-                expect(f.base_uri).to eq "http://example/"
-                expect(f.read).to eq "foo"
-                opened.opened
-              end
-            end
-
-            it "follows 302 and uses new location" do
-              WebMock.stub_request(:get, uri).to_return({status: 302, headers: {"Location" => "http://example/"}})
-              WebMock.stub_request(:get, "http://example/").to_return({body: "foo"})
-              RDF::Util::File.open_file(uri, use_net_http: with_net_http) do |f|
-                expect(f.base_uri).to eq "http://example/"
-                expect(f.read).to eq "foo"
-                opened.opened
-              end
-            end
-
-            it "follows 303 and uses new location" do
-              WebMock.stub_request(:get, uri).to_return({status: 303, headers: {"Location" => "http://example/"}})
-              WebMock.stub_request(:get, "http://example/").to_return({body: "foo"})
-              RDF::Util::File.open_file(uri, use_net_http: with_net_http) do |f|
-                expect(f.base_uri).to eq "http://example/"
-                expect(f.read).to eq "foo"
-                opened.opened
-              end
-            end
-
-            it "follows 307 and uses new location" do
-              WebMock.stub_request(:get, uri).to_return({status: 307, headers: {"Location" => "http://example/"}})
-              WebMock.stub_request(:get, "http://example/").to_return({body: "foo"})
-              RDF::Util::File.open_file(uri, use_net_http: with_net_http) do |f|
-                expect(f.base_uri).to eq "http://example/"
-                expect(f.read).to eq "foo"
-                opened.opened
-              end
-            end
-          end
-
-          context "proxy" do
-            it "requests through proxy" do
-              WebMock.stub_request(:get, uri).
-                to_return(body: File.read(File.expand_path("../../etc/doap.nt", __FILE__)),
-                          status: 200,
-                          headers: { 'Content-Type' => RDF::NTriples::Format.content_type.first})
-              RDF::Util::File.open_file(uri, use_net_http: with_net_http, proxy: "http://proxy.example.com") do |f|
-                opened.opened
-              end
-              expect(WebMock).to have_requested(:get, uri)
-            end
+            expect(WebMock).to have_requested(:get, uri)
           end
         end
 
@@ -224,7 +251,7 @@ describe RDF::Util::File do
               to_return(body: "foo",
                         status: 200,
                         headers: { 'Content-Type' => RDF::NTriples::Format.content_type.first})
-            f = RDF::Util::File.open_file(uri, use_net_http: with_net_http)
+            f = RDF::Util::File.open_file(uri)
             expect(f).to respond_to(:read)
             expect(f.content_type).to eq RDF::NTriples::Format.content_type.first
             expect(f.code).to eq 200
@@ -266,7 +293,7 @@ describe RDF::Util::File do
                             'Content-Type' => RDF::NTriples::Format.content_type.first,
                             'Link' => input
                           })
-              RDF::Util::File.open_file(uri, use_net_http: with_net_http) do |f|
+              RDF::Util::File.open_file(uri) do |f|
                 expect(f).to respond_to(:read)
                 expect(f.links.to_a).to eq output
                 opened.opened
@@ -282,12 +309,23 @@ describe RDF::Util::File do
                           'Content-Type' => RDF::NTriples::Format.content_type.first,
                           'Link' => '<http://example.com/foo> rel="describedby" type="application/n-triples"'
                         })
-            RDF::Util::File.open_file(uri, use_net_http: with_net_http) do |f|
+            RDF::Util::File.open_file(uri) do |f|
               expect(f.links.find_link(['rel', 'describedby']).to_a).to eq ['http://example.com/foo', [%w(rel describedby)]]
               opened.opened
             end
           end
         end
+      end
+      
+      context "using Net::HTTP" do
+        let(:http_adapter) { RDF::Util::File::NetHttpAdapter }
+        it_behaves_like "using a HTTP client"
+      end
+      
+      context "using RestClient" do
+        let(:http_adapter) { RDF::Util::File::RestClientAdapter }
+        require 'rest_client'
+        it_behaves_like "using a HTTP client"
       end
     end
   end


### PR DESCRIPTION
We're finding ourselves wanting to use a different REST client (Faraday, perhaps?) with `RDF::Util::File` (see sul-dlss/triannon-service#7 and our woes with rest-client-components (#174) and caching). While I'd happily add a Faraday implementation as-is, it seems like it's time for some kind of pluggable pattern. This is one such approach, and it seemed like it kept the changes to a minimum.