### PR TITLE
RDF::Util::File.open_uri should mark application/xhtml+xml as less preferred than other RDF flavors

### DIFF
--- a/lib/rdf/util/file.rb
+++ b/lib/rdf/util/file.rb
@@ -41,7 +41,14 @@ module RDF; module Util
       def self.default_accept_header
         # Receive text/html and text/plain at a lower priority than other formats
         reader_types = RDF::Format.reader_types.map do |t|
-          t.to_s =~ /text\/(?:plain|html)/  ? "#{t};q=0.5" : t
+          case t.to_s
+          when /text\/(?:plain|html)/
+            "#{t};q=0.5"
+          when /application\/xhtml\+xml/
+            "#{t};q=0.7"
+          else
+            t
+          end
         end
 
         (reader_types + %w(*/*;q=0.1)).join(", ")

--- a/spec/util_file_spec.rb
+++ b/spec/util_file_spec.rb
@@ -24,6 +24,24 @@ describe RDF::Util::File do
     end
   end
 
+  describe RDF::Util::File::HttpAdapter do
+    describe ".default_accept_header" do
+      subject { RDF::Util::File::HttpAdapter.default_accept_header.split(", ") }
+      before do
+        allow(RDF::Format).to receive(:reader_types).and_return(["text/html", "text/plain", "application/xhtml+xml"])
+      end
+      it "should demote text/html to q=0.5" do
+        expect(subject).to include "text/html;q=0.5"
+      end
+      it "should demote text/plain to q=0.5" do
+        expect(subject).to include "text/plain;q=0.5"
+      end
+      it "should demote application/xhtml+xml to q=0.7" do
+        expect(subject).to include "application/xhtml+xml;q=0.7"
+      end
+    end
+  end
+
   describe RDF::Util::File::FaradayAdapter do
     let(:http_adapter) { RDF::Util::File::FaradayAdapter }
     require 'faraday'
@@ -47,6 +65,7 @@ describe RDF::Util::File do
       end
     end
   end
+
   describe ".open_file" do
     let(:uri) {"http://ruby-rdf.github.com/rdf/etc/doap.nt"}
     let(:opened) {double("opened")}


### PR DESCRIPTION
As we're marking down `text/html`, `RDF::Util::File` should also demote `application/xhtml+xml` too.