### PR TITLE
Update specs to use new style shared_examples

### DIFF
--- a/spec/format_spec.rb
+++ b/spec/format_spec.rb
@@ -20,13 +20,11 @@ class RDF::Format::BarFormat < RDF::Format
 end
 
 describe RDF::Format do
-  before(:each) do
-    @format_class = RDF::Format
-  end
-  
+  let(:format_class) { RDF::Format }
+
   # @see lib/rdf/spec/format.rb in rdf-spec
-  include RDF_Format
-  
+  it_behaves_like 'an RDF::Format'
+
   # If there are multiple formats that assert the same type or extension,
   # Format.for should yield to return a sample used for detection
   describe ".for" do
@@ -133,7 +131,7 @@ describe RDF::Format do
         class RDF::NTriples::Format < RDF::Format
           content_type     'application/n-triples', :extension => :nt
           content_encoding 'utf-8'
-          
+
           reader RDF::NTriples::Reader
           writer RDF::NTriples::Writer
         end

--- a/spec/mixin_countable_spec.rb
+++ b/spec/mixin_countable_spec.rb
@@ -2,12 +2,10 @@ require File.join(File.dirname(__FILE__), 'spec_helper')
 require 'rdf/spec/countable'
 
 describe RDF::Countable do
-  before :each do
-    # The available reference implementations are `RDF::Repository` and
-    # `RDF::Graph`, but a plain Ruby array will do fine as well:
-    @countable = RDF::Spec.quads.extend(RDF::Countable)
-  end
+  # The available reference implementations are `RDF::Repository` and
+  # `RDF::Graph`, but a plain Ruby array will do fine as well:
+  let(:countable) { RDF::Spec.quads.extend(RDF::Countable) }
 
   # @see lib/rdf/spec/countable.rb in rdf-spec
-  include RDF_Countable
+  it_behaves_like 'an RDF::Countable'
 end

--- a/spec/mixin_durable.rb
+++ b/spec/mixin_durable.rb
@@ -2,13 +2,11 @@ require File.join(File.dirname(__FILE__), 'spec_helper')
 require 'rdf/spec/durable'
 
 describe RDF::Durable do
-  before :each do
-    # The available reference implementations are `RDF::Repository` and
-    # `RDF::Graph`, but a plain Ruby array will do fine as well
-    # FIXME
-    @load_durable = lambda {RDF::Repository.new}
-  end
+  # The available reference implementations are `RDF::Repository` and
+  # `RDF::Graph`, but a plain Ruby array will do fine as well
+  # FIXME
+  before { @load_durable = lambda { RDF::Repository.new } }
 
   # @see lib/rdf/spec/countable.rb in rdf-spec
-  include RDF_Durable
+  it_behaves_like 'an RDF::Durable'
 end

--- a/spec/mixin_enumerable_spec.rb
+++ b/spec/mixin_enumerable_spec.rb
@@ -2,17 +2,15 @@ require File.join(File.dirname(__FILE__), 'spec_helper')
 require 'rdf/spec/enumerable'
 
 describe RDF::Enumerable do
-  before :each do
-    # The available reference implementations are `RDF::Repository` and
-    # `RDF::Graph`, but a plain Ruby array will do fine as well:
-    @enumerable = RDF::Spec.quads.extend(RDF::Enumerable)
-  end
+  # The available reference implementations are `RDF::Repository` and
+  # `RDF::Graph`, but a plain Ruby array will do fine as well:
+  let(:enumerable) { RDF::Spec.quads.extend(RDF::Enumerable) }
 
   # @see lib/rdf/spec/enumerable.rb in rdf-spec
-  include RDF_Enumerable
+  it_behaves_like 'an RDF::Enumerable'
 
   context "Examples" do
-    subject {@enumerable}
+    subject { enumerable }
 
     context "Checking whether any statements exist" do
       subject {[].extend(RDF::Enumerable)}

--- a/spec/mixin_inferable_spec.rb
+++ b/spec/mixin_inferable_spec.rb
@@ -3,5 +3,5 @@ require 'rdf/spec/inferable'
 
 describe RDF::Inferable do
   # @see lib/rdf/spec/enumerable.rb in rdf-spec
-  include RDF_Inferable
+  it_behaves_like 'an RDF::Inferable'
 end

--- a/spec/mixin_mutable_spec.rb
+++ b/spec/mixin_mutable_spec.rb
@@ -2,12 +2,10 @@ require File.join(File.dirname(__FILE__), 'spec_helper')
 require 'rdf/spec/mutable'
 
 describe RDF::Mutable do
-  before :each do
-    # The available reference implementations are `RDF::Repository` and
-    # `RDF::Graph`
-    @mutable = RDF::Repository.new
-  end
+  # The available reference implementations are `RDF::Repository` and
+  # `RDF::Graph`
+  let(:mutable) { RDF::Repository.new }
 
   # @see lib/rdf/spec/mutable.rb in rdf-spec
-  include RDF_Mutable
+  it_behaves_like 'an RDF::Mutable'
 end

--- a/spec/mixin_queryable_spec.rb
+++ b/spec/mixin_queryable_spec.rb
@@ -2,20 +2,18 @@ require File.join(File.dirname(__FILE__), 'spec_helper')
 require 'rdf/spec/queryable'
 
 describe RDF::Queryable do
-  before :each do
-    # The available reference implementations are `RDF::Repository` and
-    # `RDF::Graph`, but a subclass of Ruby Array implementing
-    # `query_pattern` and `query_execute` should do as well
-    # FIXME
-    @queryable = RDF::Repository.new
-  end
+  # The available reference implementations are `RDF::Repository` and
+  # `RDF::Graph`, but a subclass of Ruby Array implementing
+  # `query_pattern` and `query_execute` should do as well
+  # FIXME
+  let(:queryable) { RDF::Repository.new }
 
   # @see lib/rdf/spec/queryable.rb in rdf-spec
-  include RDF_Queryable
+  it_behaves_like 'an RDF::Queryable'
 
   context "Examples" do
-    before(:each) {@queryable.insert(*RDF::Spec.quads)}
-    subject {@queryable}
+    before(:each) { queryable.insert(*RDF::Spec.quads) }
+    subject { queryable }
 
     context "Querying for statements having a given predicate" do
       it "with array" do

--- a/spec/model_graph_spec.rb
+++ b/spec/model_graph_spec.rb
@@ -102,11 +102,9 @@ describe RDF::Graph do
 
   context "as repository" do
     require 'rdf/spec/repository'
-    before :each do
-      @repository = @new.call
-    end
+    let(:repository) { @new.call }
 
-    include RDF_Repository
+    it_behaves_like 'an RDF::Repository'
   end
 
   context "Examples" do

--- a/spec/nquads_spec.rb
+++ b/spec/nquads_spec.rb
@@ -6,14 +6,12 @@ require 'rdf/spec/reader'
 require 'rdf/spec/writer'
 
 describe RDF::NQuads::Format do
-  before(:each) do
-    @format_class = RDF::NQuads::Format
-  end
-  
-  # @see lib/rdf/spec/format.rb in rdf-spec
-  include RDF_Format
+  let(:format_class) { RDF::NQuads::Format }
 
-  subject {@format_class}
+  # @see lib/rdf/spec/format.rb in rdf-spec
+  it_behaves_like 'an RDF::Format'
+
+  subject { format_class }
 
   describe ".for" do
     formats = [
@@ -91,15 +89,13 @@ describe RDF::NQuads::Reader do
   let(:testfile) {fixture_path('test.nq')}
   let!(:test_count) {File.open(testfile).each_line.to_a.reject {|l| l.sub(/#.*$/, '').strip.empty?}.length}
 
-  before(:each) do
-    @reader_class = RDF::NQuads::Reader
-    @reader = RDF::NQuads::Reader.new
-    @reader_input = File.read(testfile)
-    @reader_count = test_count
-  end
-  
+  let(:reader_class) { RDF::NQuads::Reader }
+  let(:reader) { RDF::NQuads::Reader.new }
+  let(:reader_input) { File.read(testfile) }
+  let(:reader_count) { test_count }
+
   # @see lib/rdf/spec/reader.rb in rdf-spec
-  include RDF_Reader
+  it_behaves_like 'an RDF::Reader'
 
   describe ".for" do
     formats = [
@@ -118,15 +114,15 @@ describe RDF::NQuads::Reader do
 
   context "when created" do
     it "should accept files" do
-      expect { @reader_class.new(File.open(testfile)) }.to_not raise_error
+      expect { reader_class.new(File.open(testfile)) }.to_not raise_error
     end
 
     it "should accept IO streams" do
-      expect { @reader_class.new(StringIO.new('')) }.to_not raise_error
+      expect { reader_class.new(StringIO.new('')) }.to_not raise_error
     end
 
     it "should accept strings" do
-      expect { @reader_class.new('') }.to_not raise_error
+      expect { reader_class.new('') }.to_not raise_error
     end
   end
 
@@ -136,15 +132,15 @@ describe RDF::NQuads::Reader do
     end
 
     it "should accept files" do
-      expect { @reader_class.new(File.open(@testfile)) }.to_not raise_error
+      expect { reader_class.new(File.open(@testfile)) }.to_not raise_error
     end
 
     it "should accept IO streams" do
-      expect { @reader_class.new(StringIO.new('')) }.to_not raise_error
+      expect { reader_class.new(StringIO.new('')) }.to_not raise_error
     end
 
     it "should accept strings" do
-      expect { @reader_class.new('') }.to_not raise_error
+      expect { reader_class.new('') }.to_not raise_error
     end
   end
 
@@ -156,13 +152,13 @@ describe RDF::NQuads::Reader do
       ['_:a <b> <c> .', RDF::Statement.new(RDF::Node.new("a"), RDF::URI("b"), RDF::URI("c"))],
     ].each do |(str, statement)|
       it "parses #{str.inspect}" do
-        graph = RDF::Graph.new << @reader_class.new(str)
+        graph = RDF::Graph.new << reader_class.new(str)
         expect(graph.size).to eq 1
         expect(graph.statements.first).to eq statement
       end
     end
   end
-  
+
   context "with simple quads" do
     [
       ['<a> <b> <c> <d> .', RDF::Statement.new(RDF::URI("a"), RDF::URI("b"), RDF::URI("c"), context: RDF::URI("d"))],
@@ -170,15 +166,15 @@ describe RDF::NQuads::Reader do
       ['<a> <b> <c> "d" .', RDF::Statement.new(RDF::URI("a"), RDF::URI("b"), RDF::URI("c"), context: RDF::Literal("d"))],
     ].each do |(str, statement)|
       it "parses #{str.inspect}" do
-        graph = RDF::Graph.new << @reader_class.new(str)
+        graph = RDF::Graph.new << reader_class.new(str)
         expect(graph.size).to eq 1
         expect(graph.statements.first).to eq statement
       end
-      
+
       it "serializes #{statement.inspect}" do
         expect(RDF::NQuads.serialize(statement).chomp).to eq str
       end
-      
+
       it "unserializes #{str.inspect}" do
         expect(RDF::NQuads.unserialize(str)).to eq statement
       end
@@ -186,17 +182,15 @@ describe RDF::NQuads::Reader do
   end
 
   it "should parse W3C's test data" do
-    expect(@reader_class.new(File.open(testfile)).to_a.size).to eq 19
+    expect(reader_class.new(File.open(testfile)).to_a.size).to eq 19
   end
 end
 
 describe RDF::NQuads::Writer do
-  before(:each) do
-    @writer_class = RDF::NQuads::Writer
-    @writer = RDF::NQuads::Writer.new
-  end
+  let(:writer_class) { RDF::NQuads::Writer }
+  let(:writer) { RDF::NQuads::Writer.new }
 
-  subject {@writer}
+  subject { writer}
 
   describe ".for" do
     formats = [
@@ -211,10 +205,10 @@ describe RDF::NQuads::Writer do
       end
     end
   end
-  
+
   # @see lib/rdf/spec/writer.rb in rdf-spec
-  include RDF_Writer
-  
+  it_behaves_like 'an RDF::Writer'
+
   context "#initialize" do
     describe "writing statements" do
       context "with simple triples" do
@@ -225,7 +219,7 @@ describe RDF::NQuads::Writer do
           ['_:a <b> <c> .', RDF::Statement.new(RDF::Node.new("a"), RDF::URI("b"), RDF::URI("c"))],
         ].each do |(str, statement)|
           it "writes #{str.inspect}" do
-            expect(@writer_class.buffer {|w| w << statement}).to eq "#{str}\n"
+            expect(writer_class.buffer {|w| w << statement}).to eq "#{str}\n"
           end
         end
       end
@@ -237,7 +231,7 @@ describe RDF::NQuads::Writer do
           ['<a> <b> <c> "d" .', RDF::Statement.new(RDF::URI("a"), RDF::URI("b"), RDF::URI("c"), context: RDF::Literal("d"))],
         ].each do |(str, statement)|
           it "writes #{str.inspect}" do
-            expect(@writer_class.buffer {|w| w << statement}).to eq "#{str}\n"
+            expect(writer_class.buffer {|w| w << statement}).to eq "#{str}\n"
           end
         end
       end
@@ -253,14 +247,14 @@ describe RDF::NQuads::Writer do
     }
     it "#insert" do
       expect do
-        @writer_class.new.insert(graph)
+        writer_class.new.insert(graph)
       end.to write("<s> <p> <o1> .\n<s> <p> <o2> .\n")
     end
 
     it "#write_graph (DEPRECATED)" do
       expect do
         expect do
-          @writer_class.new.write_graph(graph)
+          writer_class.new.write_graph(graph)
         end.to write("<s> <p> <o1> .\n<s> <p> <o2> .\n")
       end.to write('[DEPRECATION]').to(:error)
     end
@@ -273,14 +267,14 @@ describe RDF::NQuads::Writer do
     ]}
     it "#insert" do
       expect do
-        @writer_class.new.insert(*statements)
+        writer_class.new.insert(*statements)
       end.to write("<s> <p> <o1> .\n<s> <p> <o2> .\n")
     end
 
     it "#write_statements (DEPRECATED)" do
       expect do
         expect do
-          @writer_class.new.write_statements(*statements)
+          writer_class.new.write_statements(*statements)
         end.to write("<s> <p> <o1> .\n<s> <p> <o2> .\n")
       end.to write('[DEPRECATION]').to(:error)
     end
@@ -289,11 +283,11 @@ describe RDF::NQuads::Writer do
   context "Nodes" do
     let(:statement) {RDF::Statement(RDF::Node("a"), RDF.type, RDF::Node("b"), context: RDF::Node("c"))}
     it "uses node lables by default" do
-      expect(@writer_class.buffer {|w| w << statement}).to match %r(_:a <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> _:b _:c \.)
+      expect(writer_class.buffer {|w| w << statement}).to match %r(_:a <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> _:b _:c \.)
     end
 
     it "uses unique labels if :unique_bnodes is true" do
-      expect(@writer_class.buffer(unique_bnodes:true) {|w| w << statement}).to match %r(_:g\w+ <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> _:g\w+ _:g\w+ \.)
+      expect(writer_class.buffer(unique_bnodes:true) {|w| w << statement}).to match %r(_:g\w+ <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> _:g\w+ _:g\w+ \.)
     end
   end
 

--- a/spec/ntriples_spec.rb
+++ b/spec/ntriples_spec.rb
@@ -6,14 +6,12 @@ require 'rdf/spec/reader'
 require 'rdf/spec/writer'
 
 describe RDF::NTriples::Format do
-  before(:each) do
-    @format_class = RDF::NTriples::Format
-  end
-  
-  # @see lib/rdf/spec/format.rb in rdf-spec
-  include RDF_Format
+  let(:format_class) { RDF::NTriples::Format }
 
-  subject {@format_class}
+  # @see lib/rdf/spec/format.rb in rdf-spec
+  it_behaves_like 'an RDF::Format'
+
+  subject { format_class }
 
   describe ".for" do
     formats = [
@@ -47,7 +45,7 @@ describe RDF::NTriples::Format do
   describe "#name" do
     specify {expect(subject.name).to eq "N-Triples"}
   end
-  
+
   describe ".detect" do
     {
       :ntriples => "<a> <b> <c> .",
@@ -78,14 +76,14 @@ end
 describe RDF::NTriples::Reader do
   let!(:doap) {File.expand_path("../../etc/doap.nt", __FILE__)}
   let!(:doap_count) {File.open(doap).each_line.to_a.length}
-  before(:each) do
-    @reader = RDF::NTriples::Reader.new
-    @reader_input = File.read(doap)
-    @reader_count = doap_count
-  end
-  
+
+  let(:reader_class) { RDF::NTriples::Reader }
+  let(:reader) { RDF::NTriples::Reader.new }
+  let(:reader_input) { File.read(doap) }
+  let(:reader_count) { doap_count }
+
   # @see lib/rdf/spec/reader.rb in rdf-spec
-  include RDF_Reader
+  it_behaves_like 'an RDF::Reader'
 
   describe ".for" do
     formats = [
@@ -116,8 +114,8 @@ describe RDF::NTriples::Reader do
   end
 
   it "should return :ntriples for to_sym" do
-    expect(@reader.class.to_sym).to eq :ntriples
-    expect(@reader.to_sym).to eq :ntriples
+    expect(reader.class.to_sym).to eq :ntriples
+    expect(reader.to_sym).to eq :ntriples
   end
 
   describe ".initialize" do
@@ -154,7 +152,7 @@ describe RDF::NTriples::Reader do
     }.each do |sp, l|
       it "unescapes #{sp} to #{l.inspect}" do
         expect do
-          expect(@reader_class.unescape(sp)).to eq l
+          expect(reader_class.unescape(sp)).to eq l
         end.to write('[DEPRECATION]').to(:error)
       end
     end
@@ -162,12 +160,10 @@ describe RDF::NTriples::Reader do
 end
 
 describe RDF::NTriples::Writer do
-  before(:each) do
-    @writer_class = RDF::NTriples::Writer
-    @writer = RDF::NTriples::Writer.new
-  end
+  let(:writer_class) { RDF::NTriples::Writer }
+  let(:writer) { RDF::NTriples::Writer.new }
 
-  subject {@writer}
+  subject { writer }
 
   describe ".for" do
     formats = [
@@ -185,7 +181,7 @@ describe RDF::NTriples::Writer do
   end
 
   # @see lib/rdf/spec/writer.rb in rdf-spec
-  include RDF_Writer
+  it_behaves_like 'an RDF::Writer'
 
   it "defaults validation to be true" do
     expect(subject).to be_validate
@@ -204,14 +200,14 @@ describe RDF::NTriples::Writer do
     }
     it "#insert" do
       expect do
-        @writer_class.new($stdout, validate: false).insert(graph)
+        writer_class.new($stdout, validate: false).insert(graph)
       end.to write("<s> <p> <o1> .\n<s> <p> <o2> .\n")
     end
 
     it "#write_graph (DEPRECATED)" do
       expect do
         expect do
-          @writer_class.new($stdout, validate: false).write_graph(graph)
+          writer_class.new($stdout, validate: false).write_graph(graph)
         end.to write("<s> <p> <o1> .\n<s> <p> <o2> .\n")
       end.to write('[DEPRECATION]').to(:error)
     end
@@ -224,14 +220,14 @@ describe RDF::NTriples::Writer do
     ]}
     it "#insert" do
       expect do
-        @writer_class.new($stdout, validate: false).insert(*statements)
+        writer_class.new($stdout, validate: false).insert(*statements)
       end.to write("<s> <p> <o1> .\n<s> <p> <o2> .\n")
     end
 
     it "#write_statements (DEPRECATED)" do
       expect do
         expect do
-          @writer_class.new($stdout, validate: false).write_statements(*statements)
+          writer_class.new($stdout, validate: false).write_statements(*statements)
         end.to write("<s> <p> <o1> .\n<s> <p> <o2> .\n")
       end.to write('[DEPRECATION]').to(:error)
     end
@@ -240,11 +236,11 @@ describe RDF::NTriples::Writer do
   context "Nodes" do
     let(:statement) {RDF::Statement(RDF::Node("a"), RDF.type, RDF::Node("b"))}
     it "uses node lables by default" do
-      expect(@writer_class.buffer {|w| w << statement}).to match %r(_:a <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> _:b \.)
+      expect(writer_class.buffer {|w| w << statement}).to match %r(_:a <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> _:b \.)
     end
 
     it "uses unique labels if :unique_bnodes is true" do
-      expect(@writer_class.buffer(unique_bnodes:true) {|w| w << statement}).to match %r(_:g\w+ <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> _:g\w+ \.)
+      expect(writer_class.buffer(unique_bnodes:true) {|w| w << statement}).to match %r(_:g\w+ <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> _:g\w+ \.)
     end
   end
 
@@ -559,7 +555,7 @@ describe RDF::NTriples do
         expect(stmt.subject).to eq stmt.object
         expect(stmt.subject).to be_eql(stmt.object)
       end
-      
+
       it "should read two named nodes in different instances as different nodes" do
         stmt1 = @reader.unserialize("_:a <http://www.w3.org/2002/07/owl#sameAs> _:a .".freeze)
         stmt2 = @reader.unserialize("_:a <http://www.w3.org/2002/07/owl#sameAs> _:a .".freeze)
@@ -567,7 +563,7 @@ describe RDF::NTriples do
         expect(stmt1.subject).not_to be_eql(stmt2.subject)
       end
     end
-    
+
     describe "with literal encodings" do
       {
         'Dürst'          => '_:a <http://pred> "D\u00FCrst" .',

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -2,25 +2,21 @@ require File.join(File.dirname(__FILE__), 'spec_helper')
 require 'rdf/spec/repository'
 
 describe RDF::Repository do
-  before :each do
-    @repository = RDF::Repository.new
-  end
+  let(:repository) { RDF::Repository.new }
 
   # @see lib/rdf/spec/repository.rb in rdf-spec
-  include RDF_Repository
+  it_behaves_like 'an RDF::Repository'
 
   it "should maintain arbitrary options" do
-    @repository = RDF::Repository.new(:foo => :bar)
-    expect(@repository.options).to have_key(:foo)
-    expect(@repository.options[:foo]).to eq :bar
+    repository = RDF::Repository.new(:foo => :bar)
+    expect(repository.options).to have_key(:foo)
+    expect(repository.options[:foo]).to eq :bar
   end
 
   context "A non-validatable repository" do
-    before :each do
-      @repository = RDF::Repository.new(:with_validity => false)
-    end
+    let(:repository) { RDF::Repository.new(:with_validity => false) }
 
     # @see lib/rdf/spec/repository.rb in rdf-spec
-    include RDF_Repository
+    it_behaves_like 'an RDF::Repository'
   end
 end

--- a/spec/transaction_spec.rb
+++ b/spec/transaction_spec.rb
@@ -3,5 +3,5 @@ require 'rdf/spec/transaction'
 
 describe RDF::Transaction do
   # @see lib/rdf/spec/transaction.rb in rdf-spec
-  it_behaves_like "RDF_Transaction", RDF::Transaction
+  it_behaves_like "an RDF::Transaction", RDF::Transaction
 end

--- a/spec/util_file_spec.rb
+++ b/spec/util_file_spec.rb
@@ -12,12 +12,12 @@ describe RDF::Util::File do
       hide_const("RestClient")
       expect(RDF::Util::File.http_adapter).to eq RDF::Util::File::NetHttpAdapter
     end
-    
+
     it "returns RestClient if rest-client is available" do
       require 'rest-client'
       expect(RDF::Util::File.http_adapter).to eq RDF::Util::File::RestClientAdapter
     end
-    
+
     it "return Net::HTTP if explicitly requested" do
       require 'rest-client'
       expect(RDF::Util::File.http_adapter(true)).to eq RDF::Util::File::NetHttpAdapter
@@ -96,7 +96,7 @@ describe RDF::Util::File do
       end
       expect(r).to be_a(RDF::Reader)
     end
-    
+
     it "yields a file URL" do
       r = RDF::Util::File.open_file("file:" + fixture_path("test.nt")) do |f|
         expect(f).to respond_to(:read)
@@ -123,30 +123,24 @@ describe RDF::Util::File do
     require 'rdf/spec/http_adapter'
 
     context "using Net::HTTP" do
-      before do
-        @http_adapter = RDF::Util::File::NetHttpAdapter
-      end
+      let(:http_adapter) { RDF::Util::File::NetHttpAdapter }
 
-      include RDF_HttpAdapter
+      it_behaves_like 'an RDF::HttpAdapter'
     end
-    
-    context "using RestClient" do
-      before do
-        require 'rest_client'
-        @http_adapter = RDF::Util::File::RestClientAdapter
-      end
 
-      include RDF_HttpAdapter
+    context "using RestClient" do
+      require 'rest_client'
+      let(:http_adapter) { RDF::Util::File::RestClientAdapter }
+
+      it_behaves_like 'an RDF::HttpAdapter'
     end
 
     context "using Faraday" do
-      before do
-        require 'faraday'
-        require 'faraday_middleware'
-        @http_adapter = RDF::Util::File::FaradayAdapter
-      end
+      require 'faraday'
+      require 'faraday_middleware'
+      let(:http_adapter) { RDF::Util::File::FaradayAdapter }
 
-      include RDF_HttpAdapter
+      it_behaves_like 'an RDF::HttpAdapter'
     end
   end
 end


### PR DESCRIPTION
This represents a (fairly) minimal update of the rspec examples to use the new style of shared examples, e.g.: `it_behaves_like 'an RDF::Writer'`.