### PR TITLE
Loosen hash check on `Node#==`

### DIFF
--- a/lib/rdf/model/node.rb
+++ b/lib/rdf/model/node.rb
@@ -146,9 +146,9 @@ module RDF
       when Literal
         # If other is a Literal, reverse test to consolodate complex type checking logic
         other == self
-      else 
+      else
         other.respond_to?(:node?) && other.node? &&
-          self.hash == other.hash &&
+          self.hash == other.to_term.hash &&
           other.respond_to?(:id) && @id == other.id
       end
     end


### PR DESCRIPTION
`Node#==` now compares itself to the hash of`other#to_term`, rather than other itself. This makes it possible to do comparisons with other object types implementing the `Node` interface.

Merge with care. `Node#==` is significantly under-tested, and removing the altered line (and the one above it) entirely, doesn't cause any failures.