### PR TITLE
Hard code class names for RDF::Reader & Writer tests

### DIFF
--- a/spec/nquads_spec.rb
+++ b/spec/nquads_spec.rb
@@ -92,9 +92,9 @@ describe RDF::NQuads::Reader do
 
   # @see lib/rdf/spec/reader.rb in rdf-spec
   it_behaves_like 'an RDF::Reader' do
-    let(:reader) { described_class.new }
+    let(:reader) { RDF::NQuads::Reader.new }
     let(:reader_input) { File.read(testfile) }
-    let(:reader_count) { test_count }
+    let(:reader_count) { 19 }
   end
 
   describe ".for" do
@@ -187,7 +187,7 @@ describe RDF::NQuads::Reader do
 end
 
 describe RDF::NQuads::Writer do
-  subject { described_class.new}
+  subject { RDF::NQuads::Writer.new }
 
   describe ".for" do
     formats = [
@@ -205,7 +205,7 @@ describe RDF::NQuads::Writer do
 
   # @see lib/rdf/spec/writer.rb in rdf-spec
   it_behaves_like 'an RDF::Writer' do
-    let(:writer) { described_class.new }
+    let(:writer) { RDF::NQuads::Writer.new }
   end
 
   context "#initialize" do

--- a/spec/ntriples_spec.rb
+++ b/spec/ntriples_spec.rb
@@ -77,11 +77,11 @@ end
 describe RDF::NTriples::Reader do
   let!(:doap) {File.expand_path("../../etc/doap.nt", __FILE__)}
   let!(:doap_count) {File.open(doap).each_line.to_a.length}
-  subject {described_class.new}
+  subject { RDF::NTriples::Reader.new }
 
   # @see lib/rdf/spec/reader.rb in rdf-spec
   it_behaves_like 'an RDF::Reader' do
-    let(:reader) { described_class.new }
+    let(:reader) { RDF::NTriples::Reader.new }
     let(:reader_input) { File.read(doap) }
     let(:reader_count) { doap_count }
   end


### PR DESCRIPTION
The reader and writer tests called `described_class` to define their target object. This was causing problems in "an RDF::Enumerable" examples, where `described_class` changes to `RDF::Enumerable`.

This hard codes the class, instead of using RSpec's lambda.