### PR TITLE
Rely `Term#to_term` when setting statement values

### DIFF
--- a/lib/rdf/model/statement.rb
+++ b/lib/rdf/model/statement.rb
@@ -103,7 +103,6 @@ module RDF
       @subject   = case @subject
         when nil      then nil
         when Symbol   then Node.intern(@subject)
-        when Term     then @subject
         when Value    then @subject.to_term
         else          raise ArgumentError, "expected subject to be nil or a term, was #{@subject.inspect}"
       end
@@ -111,7 +110,6 @@ module RDF
       @object    = case @object
         when nil    then nil
         when Symbol then Node.intern(@object)
-        when Term   then @object
         when Value  then @object.to_term
         else Literal.new(@object)
       end


### PR DESCRIPTION
This allows other objects (e.g. `ActiveTriples::RDFSource`) to implement the `Term` interface and work correctly within `RDF::Statements`. Existing `Terms` respond to `#to_term` with `self`.

See: https://github.com/ActiveTriples/ActiveTriples/issues/100