### PR TITLE
Enable Ruby-idiomatic aliases for camelCased props

### DIFF
--- a/lib/rdf/vocabulary.rb
+++ b/lib/rdf/vocabulary.rb
@@ -59,6 +59,16 @@ module RDF
   #   foaf.knows    #=> RDF::URI("http://xmlns.com/foaf/0.1/knows")
   #   foaf[:name]   #=> RDF::URI("http://xmlns.com/foaf/0.1/name")
   #   foaf['mbox']  #=> RDF::URI("http://xmlns.com/foaf/0.1/mbox")
+  # 
+  # @example Method calls are converted to the typical RDF camelcase convention
+  #   foaf = RDF::Vocabulary.new("http://xmlns.com/foaf/0.1/")
+  #   foaf.family_name    #=> RDF::URI("http://xmlns.com/foaf/0.1/familyName")
+  #   owl.same_as         #=> RDF::URI("http://www.w3.org/2002/07/owl#sameAs")
+  #   # []-style access is left as is
+  #   foaf['family_name'] #=> RDF::URI("http://xmlns.com/foaf/0.1/family_name")
+  #   foaf[:family_name]  #=> RDF::URI("http://xmlns.com/foaf/0.1/family_name")
+  #
+  #
   #
   # @example Generating RDF from a vocabulary definition
   #   graph = RDF::Graph.new << RDF::RDFS.to_enum
@@ -399,6 +409,7 @@ module RDF
       end
 
       def method_missing(property, *args, &block)
+        property = RDF::Vocabulary.camelize(property.to_s)
         if %w(to_ary).include?(property.to_s)
           super
         elsif args.empty? && !to_s.empty?
@@ -409,6 +420,7 @@ module RDF
       end
 
     private
+
       def props; @properties ||= {}; end
     end
 
@@ -472,6 +484,7 @@ module RDF
     end
 
     def method_missing(property, *args, &block)
+      property = self.class.camelize(property.to_s)
       if %w(to_ary).include?(property.to_s)
         super
       elsif args.empty?
@@ -479,6 +492,12 @@ module RDF
       else
         super
       end
+    end
+
+    def self.camelize(str)
+      str.split('_').inject([]) do |buffer, e| 
+        buffer.push(buffer.empty? ? e : e.capitalize)
+      end.join
     end
 
   private

--- a/spec/vocabulary_spec.rb
+++ b/spec/vocabulary_spec.rb
@@ -17,6 +17,11 @@ describe RDF::Vocabulary do
       expect(subject.foo).to be_a(RDF::Vocabulary::Term)
     end
 
+    it "camelizes on method_missing" do
+      expect(subject.foo_bar).to be_a(RDF::Vocabulary::Term)
+      expect(subject.foo_bar).to eq (subject.to_uri / 'fooBar')
+    end
+
     it "should allow []" do
       expect {subject["foo"]}.not_to raise_error
       expect(subject["foo"]).to be_a(RDF::Vocabulary::Term)
@@ -91,7 +96,7 @@ describe RDF::Vocabulary do
       end
 
       it "allows unknown property" do
-        expect(vocab._unknown_).to eq "#{vocab.to_uri}_unknown_"
+        expect(vocab.unknown_property).to eq "#{vocab.to_uri}unknownProperty"
       end
     end
   end
@@ -160,14 +165,19 @@ describe RDF::Vocabulary do
       expect {test_vocab.a_missing_method}.not_to raise_error
     end
 
+    it "camelizes on method_missing" do
+      expect(test_vocab.a_missing_method)
+        .to eq (test_vocab.to_uri / 'aMissingMethod')
+    end
+
     it "should respond to [] with properties that have been defined" do
       expect(test_vocab[:prop]).to be_a(RDF::URI)
       expect(test_vocab["prop2"]).to be_a(RDF::URI)
     end
 
     it "should respond to [] with properties that have not been defined" do
-      expect(test_vocab[:not_a_prop]).to be_a(RDF::URI)
-      expect(test_vocab["not_a_prop"]).to be_a(RDF::URI)
+      expect(test_vocab[:not_a_prop]).to eq (test_vocab.to_uri / 'not_a_prop')
+      expect(test_vocab["not_a_prop"]).to eq (test_vocab.to_uri / 'not_a_prop')
     end
 
     its(:property) {is_expected.to eq RDF::URI("http://example.com/test#property")}


### PR DESCRIPTION
Gives access to property names with Ruby style snake_case names in
`RDF::Vocabulary`. Names with '_' are split and rejoined, capitalizing
each segment after the first:

    FOAF.family_name == FOAF.familyName
    OWL.same_as == OWL.sameAs

You can access unusual names with []:

    FOAF[:family_name]
    #=> RDF::URI("http://xmlns.com/foaf/0.1/family_name")

Note that `VOCAB._same_as` results in `:SameAs`.

This closes #13.