### PR TITLE
fix graph context documentation

### DIFF
--- a/lib/rdf/model/graph.rb
+++ b/lib/rdf/model/graph.rb
@@ -27,7 +27,7 @@ module RDF
   #   require 'rdf/trig'  # for TriG support
   #
   #   repository = graph = RDF::Repository.load("https://raw.githubusercontent.com/ruby-rdf/rdf-trig/develop/etc/doap.trig", format: :trig))
-  #   graph = RDF::Graph.new(data: repository, context: RDF::URI("http://greggkellogg.net/foaf#me"))
+  #   graph = RDF::Graph.new(RDF::URI("http://greggkellogg.net/foaf#me"), data: repository)
   class Graph
     include RDF::Value
     include RDF::Countable


### PR DESCRIPTION
The examples for creating a Graph with context claim that you can pass a context as `:context` to the `options` hash.  This fixes the documentation to show the correct creational pattern for graphs with context.

It would be easy enough to make the initializer support this options approach, but the existing code makes no attempt to implement this feature; nor is it documented in the method level docs.  My inclination is just to fix the example.