### PR TITLE
Alternative to splat argument insert/update/delete in `RDF::Mutable` and `RDF::Writable`

### DIFF
--- a/lib/rdf/mixin/mutable.rb
+++ b/lib/rdf/mixin/mutable.rb
@@ -72,7 +72,7 @@ module RDF
     end
 
     ##
-    # Inserts RDF statements into `self`.
+    # Inserts multiple RDF statements into `self`.
     #
     # @param  [Array<RDF::Statement>] statements
     # @raise  [TypeError] if `self` is immutable
@@ -85,7 +85,24 @@ module RDF
     end
 
     ##
-    # Updates RDF statements in `self`.
+    # Efficiently inserts a single Array of RDF statements into `self`.
+    #
+    # @param  [Array<RDF::Statement>] statements
+    # @raise  [TypeError] if `self` is immutable
+    # @return [Mutable]
+    # @see    RDF::Writable#insertn
+    def insertn(statements)
+      raise TypeError.new("#{self} is immutable") if immutable?
+
+      super # RDF::Writable#insertn
+    end
+
+    ##
+    # Updates multiple RDF statements in `self`.
+    #
+    # Warning: using splat argument syntax with a lot of arguments provided
+    # significantly affects performance. Consider using RDF::Mutable#updaten
+    # to update all statements in an efficient manner.
     #
     # `#update([subject, predicate, object])` is equivalent to
     # `#delete([subject, predicate, nil])` followed by
@@ -94,7 +111,20 @@ module RDF
     # @param  [Enumerable<RDF::Statement>] statements
     # @raise  [TypeError] if `self` is immutable
     # @return [Mutable]
+    # @see    RDF::Mutable#updaten
     def update(*statements)
+      updaten(statements)
+    end
+
+    alias_method :update!, :update
+
+    ##
+    # Efficiently updates a single Array of RDF statements in `self`.
+    #
+    # @param  [Enumerable<RDF::Statement>] statements
+    # @raise  [TypeError] if `self` is immutable
+    # @return [Mutable]
+    def updaten(statements)
       raise TypeError.new("#{self} is immutable") if immutable?
 
       statements.each do |statement|
@@ -105,10 +135,28 @@ module RDF
       end
     end
 
-    alias_method :update!, :update
+    ##
+    # Deletes multiple RDF statements from `self`.
+    # If any statement contains a {Query::Variable}, it is
+    # considered to be a pattern, and used to query
+    # self to find matching statements to delete.
+    #
+    # Warning: using splat argument syntax with a lot of arguments provided
+    # significantly affects performance. Consider using RDF::Mutable#deleten
+    # to update all statements in an efficient manner.
+    #
+    # @param  [Enumerable<RDF::Statement>] statements
+    # @raise  [TypeError] if `self` is immutable
+    # @return [Mutable]
+    # @see    RDF::Mutable#deleten
+    def delete(*statements)
+      deleten(statements)
+    end
+
+    alias_method :delete!, :delete
 
     ##
-    # Deletes RDF statements from `self`.
+    # Efficiently deletes a single Array of RDF statements from `self`.
     # If any statement contains a {Query::Variable}, it is
     # considered to be a pattern, and used to query
     # self to find matching statements to delete.
@@ -116,7 +164,7 @@ module RDF
     # @param  [Enumerable<RDF::Statement>] statements
     # @raise  [TypeError] if `self` is immutable
     # @return [Mutable]
-    def delete(*statements)
+    def deleten(statements)
       raise TypeError.new("#{self} is immutable") if immutable?
 
       statements.map! do |value|
@@ -136,8 +184,6 @@ module RDF
 
       return self
     end
-
-    alias_method :delete!, :delete
 
     ##
     # Deletes all RDF statements from `self`.

--- a/lib/rdf/mixin/writable.rb
+++ b/lib/rdf/mixin/writable.rb
@@ -44,11 +44,26 @@ module RDF
     end
 
     ##
-    # Inserts RDF statements into `self`.
+    # Inserts multiple RDF statements into `self`.
+    #
+    # Warning: using splat argument syntax with a lot of arguments provided
+    # significantly affects performance. Consider using RDF::Writable#insertn
+    # to insert all statements in an efficient manner.
     #
     # @param  [Array<RDF::Statement>] statements
     # @return [RDF::Writable] `self`
+    # @see    RDF::Writable#insertn
     def insert(*statements)
+      insertn(statements)
+    end
+    alias_method :insert!, :insert
+
+    ##
+    # Efficiently inserts a single Array of RDF statements into `self`.
+    #
+    # @param  [Array<RDF::Statement>] statements
+    # @return [RDF::Writable] `self`
+    def insertn(statements)
       statements.map! do |value|
         case
           when value.respond_to?(:each_statement)
@@ -65,7 +80,6 @@ module RDF
 
       return self
     end
-    alias_method :insert!, :insert
 
   protected
 

--- a/lib/rdf/repository.rb
+++ b/lib/rdf/repository.rb
@@ -26,14 +26,16 @@ module RDF
   #   repository.each_statement { |statement| statement.inspect! }
   #
   # @example Inserting statements into a repository
-  #   repository.insert(*statements)
+  #   repository.insert(*statements) # poor performance if lots of statements!
+  #   repository.insertn(statements) # prefer this form if lots of statements.
   #   repository.insert(statement)
   #   repository.insert([subject, predicate, object])
   #   repository << statement
   #   repository << [subject, predicate, object]
   #
   # @example Deleting statements from a repository
-  #   repository.delete(*statements)
+  #   repository.delete(*statements) # poor performance if lots of statements!
+  #   repository.deleten(statements) # prefer this form if lots of statements.
   #   repository.delete(statement)
   #   repository.delete([subject, predicate, object])
   #

--- a/spec/mixin_queryable_spec.rb
+++ b/spec/mixin_queryable_spec.rb
@@ -12,7 +12,7 @@ describe RDF::Queryable do
   end
 
   context "Examples" do
-    subject { RDF::Repository.new.insert(*RDF::Spec.quads) }
+    subject { RDF::Repository.new.insertn(RDF::Spec.quads) }
 
     context "Querying for statements having a given predicate" do
       it "with array" do

--- a/spec/model_list_spec.rb
+++ b/spec/model_list_spec.rb
@@ -175,7 +175,7 @@ describe RDF::List do
       }.each do |name, list|
         it name do
           if list.is_a?(Array)
-            graph = RDF::Graph.new.insert(*list)
+            graph = RDF::Graph.new.insertn(list)
             list = RDF::List.new(list.first.subject, graph)
           end
           expect(list).to be_valid
@@ -211,7 +211,7 @@ describe RDF::List do
       }.each do |name, list|
         it name do
           if list.is_a?(Array)
-            graph = RDF::Graph.new.insert(*list)
+            graph = RDF::Graph.new.insertn(list)
             list = RDF::List.new(list.first.subject, graph)
           end
           expect(list).to be_invalid

--- a/spec/nquads_spec.rb
+++ b/spec/nquads_spec.rb
@@ -270,6 +270,12 @@ describe RDF::NQuads::Writer do
       end.to write("<s> <p> <o1> .\n<s> <p> <o2> .\n")
     end
 
+    it "#insertn" do
+      expect do
+        described_class.new.insertn(statements)
+      end.to write("<s> <p> <o1> .\n<s> <p> <o2> .\n")
+    end
+
     it "#write_statements (DEPRECATED)" do
       expect do
         expect do

--- a/spec/ntriples_spec.rb
+++ b/spec/ntriples_spec.rb
@@ -227,6 +227,12 @@ describe RDF::NTriples::Writer do
       end.to write("<s> <p> <o1> .\n<s> <p> <o2> .\n")
     end
 
+    it "#insertn" do
+      expect do
+        writer_class.new($stdout, validate: false).insertn(statements)
+      end.to write("<s> <p> <o1> .\n<s> <p> <o2> .\n")
+    end
+
     it "#write_statements (DEPRECATED)" do
       expect do
         expect do

--- a/spec/query_pattern_spec.rb
+++ b/spec/query_pattern_spec.rb
@@ -196,7 +196,7 @@ describe RDF::Query::Pattern do
   end
 
   context "Examples" do
-    let!(:repo) {RDF::Repository.new {|r| r.insert(*RDF::Spec.triples)}}
+    let!(:repo) {RDF::Repository.new {|r| r.insertn(RDF::Spec.triples)}}
     let!(:statement) {repo.detect {|s| s.to_a.none?(&:node?)}}
     let(:pattern) {described_class.new(:s, :p, :o)}
     subject {pattern}

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -806,7 +806,7 @@ describe RDF::Query do
   end
 
   describe "#each_solution" do
-    let!(:graph) {RDF::Graph.new.insert(*RDF::Spec.triples)}
+    let!(:graph) {RDF::Graph.new.insertn(RDF::Spec.triples)}
     it "enumerates solutions" do
       query = RDF::Query.new do
         pattern [:person, RDF.type, FOAF.Person]
@@ -820,7 +820,7 @@ describe RDF::Query do
   end
 
   describe "#each_statement" do
-    let!(:graph) {RDF::Graph.new.insert(*RDF::Spec.triples)}
+    let!(:graph) {RDF::Graph.new.insertn(RDF::Spec.triples)}
     it "enumerates solutions" do
       query = RDF::Query.new do
         pattern [:person, RDF.type, FOAF.Person]
@@ -886,7 +886,7 @@ describe RDF::Query do
   end
 
   context "Examples" do
-    let!(:graph) {RDF::Graph.new.insert(*RDF::Spec.triples)}
+    let!(:graph) {RDF::Graph.new.insertn(RDF::Spec.triples)}
     subject {
       query = RDF::Query.new do
         pattern [:person, RDF.type,  FOAF.Person]


### PR DESCRIPTION
This PR introduces new methods in `RDF::Writable` and `RDF::Mutable` to complement the existing `RDF::Writable#insert`, `RDF::Mutable#insert`, `RDF::Mutable#update` and `RDF::Mutable#delete` methods with a non-splat argument alternative.

The problems with splat argument syntax:
 - it is limited to 130000 statements or so, as seen [here](http://stackoverflow.com/questions/28703587/systemstackerror-when-pushing-more-than-130798-objects-into-an-array)
 - it is extremely inefficient when passing a computed Array (or other Enumerable) of statements (converting a 10000 element Array into splat argument can be 100 times slower as just passing the Array directly), as seen in JuanitoFatas/fast-ruby#76.

With the new methods `RDF::Writable#insertn`, `RDF::Mutable#insertn`, `RDF::Mutable#updaten` and `RDF::Mutable#deleten`, one can safely refactor code like [this](https://github.com/ruby-rdf/spira/blob/459d49554a064bd05be9a3442774316ea53c1b87/lib/spira/utils.rb#L24):
```ruby
repository.insert *update_repository
repository.delete *(old_subject_statements + old_object_statements)
```

To this:
```ruby
repository.insertn update_repository
repository.deleten(old_subject_statements + old_object_statements)
```