### PR TITLE
Fix named graph support in `RDF::Transaction`

### DIFF
--- a/lib/rdf/transaction.rb
+++ b/lib/rdf/transaction.rb
@@ -95,8 +95,8 @@ module RDF
         @options[:graph_name] ||= @options.delete(:context)
       end
       @graph_name = @options.delete(:graph) || @options.delete(:graph_name)
-      @inserts = @options.delete(:insert)   || RDF::Graph.new
-      @deletes = @options.delete(:delete)   || RDF::Graph.new
+      @inserts = @options.delete(:insert)   || []
+      @deletes = @options.delete(:delete)   || []
       @inserts.extend(RDF::Enumerable) unless @inserts.kind_of?(RDF::Enumerable)
       @deletes.extend(RDF::Enumerable) unless @deletes.kind_of?(RDF::Enumerable)
 


### PR DESCRIPTION
Use of `RDF::Graph` to store inserts and deletes in `RDF::Transaction`
is heavy handed, and results in the destruction of graph names on
statements passed in. This fix simply uses `[]` to handle the statement
lists (`RDF::Enumerable` is already included by force).

This should be cheaper and insulate us from potentially unwanted
behavior outside of `Enumerable`. Clients can still use `RDF::Graph` by
passing it on initialization at their own risk.