### PR TITLE
Make `Transaction#execute` more atomic

### DIFF
--- a/lib/rdf/transaction.rb
+++ b/lib/rdf/transaction.rb
@@ -130,18 +130,21 @@ module RDF
     def execute(repository, options = {})
       before_execute(repository, options) if respond_to?(:before_execute)
 
-      deletes.each_statement do |statement|
-        statement = statement.dup
+      dels = deletes.map do |s|
+        statement = s.dup
         statement.graph_name ||= graph_name
-        repository.delete(statement)
+        statement
       end
 
-      inserts.each_statement do |statement|
-        statement = statement.dup
+      ins = inserts.map do |s|
+        statement = s.dup
         statement.graph_name ||= graph_name
-        repository.insert(statement)
+        statement
       end
-
+      
+      repository.delete(*dels) unless dels.empty?
+      repository.insert(*ins) unless ins.empty?
+      
       after_execute(repository, options) if respond_to?(:after_execute)
       self
     end


### PR DESCRIPTION
Executing a transaction individually called `#delete` or `#insert` for
each statement in the changeset. This prevents using the features of
`Repositories` with a more efficient implementation of
`#insert/delete_statements`.

The patch fixes this (partially) by calling `#delete` and `#insert` only
once each for each execution, making executions faster for some
repositories and closer to being properly atomic.

A caveat, of course, is that there are still two upstream requests
required for each "transaction". We may regard that as okay, with
@bendiken's planned 2.0 changes to transaction, and seeing this
interface as a changeset.

Another option is to implement `#delete_insert(deletes, inserts)` in
`RDF::Mutable`; the base implementation could simply be to call
`#delete` and `#insert` in turn, but `Repository` specializations could
handle them as a single request. Thoughts, @gkellogg @bendiken?