### PR TITLE
Use `#clear_statements` when available

### DIFF
--- a/lib/rdf/mixin/mutable.rb
+++ b/lib/rdf/mixin/mutable.rb
@@ -153,7 +153,7 @@ module RDF
     def clear
       raise TypeError.new("#{self} is immutable") if immutable?
 
-      if respond_to?(:clear_statements)
+      if respond_to?(:clear_statements, true)
         clear_statements
       else
         delete_statements(self)


### PR DESCRIPTION
`Mutable#clear` checks whether the instance responds to
`#clear_statements` and falls back on `#delete_statements`. The former
clears the entire mutable, using e.g., `graph_name`, while the latter has
enumerative semantics (deleting the members of the set of
statements). Because `#clear_statements` is protected or private, it will
never be used by immutable without the `true` flag on `#respond_to?`.