### PR TITLE
Compare object before subject

### DIFF
--- a/lib/rdf/model/statement.rb
+++ b/lib/rdf/model/statement.rb
@@ -265,10 +265,10 @@ module RDF
     # @param  [Statement] other
     # @return [Boolean]
     def ===(other)
-      return false if has_graph?     && !graph_name.eql?(other.graph_name)
-      return false if has_subject?   && !subject.eql?(other.subject)
-      return false if has_predicate? && !predicate.eql?(other.predicate)
       return false if has_object?    && !object.eql?(other.object)
+      return false if has_predicate? && !predicate.eql?(other.predicate)
+      return false if has_subject?   && !subject.eql?(other.subject)
+      return false if has_graph?     && !graph_name.eql?(other.graph_name)
       return true
     end
 


### PR DESCRIPTION
A graph is likely to have just a few subjects, so it's not a good
differentiator. Whereas it is likely to have a great number of different
objects. Thus if we compare object we're likely to find that the
object doesn't match and avoid extra comparisons.

Notice there are fewer calls to `RDF::URI.eql?` in the second graph.

Before:
<img width="507" alt="screen shot 2015-10-29 at 11 08 03 am" src="https://cloud.githubusercontent.com/assets/92044/10824215/8af3cb0a-7e2d-11e5-88aa-06a7cd1816ed.png">

After:
<img width="503" alt="screen shot 2015-10-29 at 11 08 30 am" src="https://cloud.githubusercontent.com/assets/92044/10824221/8dad8d86-7e2d-11e5-8eef-d092a561837e.png">
