### PR TITLE
Checks default `Queryable#query` for dispatching

### DIFF
--- a/spec/mixin_queryable_spec.rb
+++ b/spec/mixin_queryable_spec.rb
@@ -15,6 +15,11 @@ describe RDF::Queryable do
     subject { RDF::Repository.new.insert(*RDF::Spec.quads) }
 
     context "Querying for statements having a given predicate" do
+      it "calls #query_pattern" do
+        is_expected.to receive(:query_pattern)
+        is_expected.not_to receive(:query_execute)
+        subject.query([:s, :p, :o]) {}
+      end
       it "with array" do
         expect(subject.query([nil, RDF::Vocab::DOAP.developer, nil]).to_a).not_to be_empty
         subject.query([nil, RDF::Vocab::DOAP.developer, nil]) {|s| expect(s).to be_a_statement}
@@ -28,8 +33,14 @@ describe RDF::Queryable do
     end
 
     context "Querying for solutions from a BGP" do
+      let(:query) { query = RDF::Query.new {pattern [:s, :p, :o]} }
+      it "calls #query_execute" do
+        is_expected.to receive(:query_execute)
+        is_expected.not_to receive(:query_pattern)
+        subject.query(query) {}
+      end
+
       it "returns solutions" do
-        query = RDF::Query.new {pattern [:s, :p, :o]}
         expect(subject.query(query).to_a).not_to be_empty
         subject.query(query) {|s| expect(s).to be_a RDF::Query::Solution}
         expect{|b| subject.query(query, &b)}.to yield_control.exactly(subject.count).times


### PR DESCRIPTION
`Queryable#query` lets users of the mixin implement `#query_execute` and `#query_pattern` as an easy path to its interface. Tests for this were removed from the shared examples by https://github.com/ruby-rdf/rdf-spec/pull/33. This reintroduces them as tests on the implementation.