### PR TITLE
Implement `Graph#insert_statements` batch insert

### DIFF
--- a/lib/rdf/model/graph.rb
+++ b/lib/rdf/model/graph.rb
@@ -301,6 +301,21 @@ module RDF
 
     ##
     # @private
+    # @see RDF::Mutable#insert_statements
+    def insert_statements(statements)
+      enum = Enumerable::Enumerator.new do |yielder|
+        
+        statements.send(method = statements.respond_to?(:each_statement) ? :each_statement : :each) do |s|
+          s = s.dup
+          s.graph_name = graph_name
+          yielder << s
+        end
+      end
+      @data.insert(enum)
+    end
+
+    ##
+    # @private
     # @see RDF::Mutable#delete
     def delete_statement(statement)
       statement = statement.dup

--- a/spec/model_graph_spec.rb
+++ b/spec/model_graph_spec.rb
@@ -86,6 +86,17 @@ describe RDF::Graph do
       expect(graph).to receive(:load).with("http://example/doc.nt", base_uri: "http://example/doc.nt")
       graph.load!
     end
+
+    it "should insert multiple statements as enumerable" do
+      graph = described_class.new(RDF::URI("http://example/doc.nt"), data: repo)
+      expect(repo).to receive(:insert_statements).with(responding_to(:each))
+
+      statements = [RDF::Statement(RDF::URI('s'), RDF::URI('p'), RDF::URI('o')),
+                    RDF::Statement(RDF::URI('x'), RDF::URI('y'), RDF::URI('z'))]
+      statements.extend(RDF::Enumerable)
+
+      graph << statements
+    end
   end
 
   it "should maintain arbitrary options" do


### PR DESCRIPTION
Graph previously avoided the multi-statement insert interfaces of its underlying `Repository`. By adding `#insert_statements`, we can use that interface, saving round-trips to external repositories.

Closes #220.