### PR TITLE
Feature/issue 244 to base format

### DIFF
--- a/lib/rdf/model/literal.rb
+++ b/lib/rdf/model/literal.rb
@@ -417,14 +417,23 @@ module RDF
     end
 
     ##
-    # Returns the base representation of this URI.
+    # Escape a literal using ECHAR escapes.
     #
-    # @return [Sring]
-    def to_base
-      text = %("#{escape(value)}")
-      text << "@#{language}" if has_language?
-      text << "^^#{datatype.to_base}" if has_datatype?
-      text
+    #    ECHAR ::= '\' [tbnrf"'\]
+    #
+    # @note N-Triples only requires '\"\n\r' to be escaped.
+    #
+    # @param  [String] string
+    # @return [String]
+    # @see {RDF::Term#escape}
+    def escape(string)
+      string.gsub('\\', '\\\\').
+             gsub("\t", '\\t').
+             gsub("\b", '\\b').
+             gsub("\n", '\\n').
+             gsub("\r", '\\r').
+             gsub("\f", '\\f').
+             gsub('"', '\\"')
     end
 
     ##

--- a/lib/rdf/model/node.rb
+++ b/lib/rdf/model/node.rb
@@ -154,14 +154,6 @@ module RDF
     alias_method :===, :==
 
     ##
-    # Returns the base representation of this node.
-    #
-    # @return [Sring]
-    def to_base
-      to_s
-    end
-
-    ##
     # Returns a representation of this node independent of any identifier used to initialize it
     #
     # @return [String]

--- a/lib/rdf/model/term.rb
+++ b/lib/rdf/model/term.rb
@@ -81,6 +81,14 @@ module RDF
     end
 
     ##
+    # Returns the base representation of this term.
+    #
+    # @return [Sring]
+    def to_base
+      RDF::NTriples.serialize(self)
+    end
+
+    ##
     # Term compatibility according to SPARQL
     #
     # @see http://www.w3.org/TR/sparql11-query/#func-arg-compatibility
@@ -91,18 +99,12 @@ module RDF
 
     protected
     ##
-    # Escape a term using standard character escapes
+    # Escape a term using escapes. This should be implemented as appropriate for the given type of term.
     #
     # @param  [String] string
     # @return [String]
     def escape(string)
-      string.gsub('\\', '\\\\').
-             gsub("\b", '\\b').
-             gsub("\f", '\\f').
-             gsub("\t", '\\t').
-             gsub("\n", '\\n').
-             gsub("\r", '\\r').
-             gsub('"', '\\"')
+      raise NotImplementedError, "#{self.class}#escape"
     end
 
   end # Term

--- a/lib/rdf/model/uri.rb
+++ b/lib/rdf/model/uri.rb
@@ -39,7 +39,7 @@ module RDF
       [\\u{40000}-\\u{4FFFD}]|[\\u{50000}-\\u{5FFFD}]|[\\u{60000}-\\u{6FFFD}]|
       [\\u{70000}-\\u{7FFFD}]|[\\u{80000}-\\u{8FFFD}]|[\\u{90000}-\\u{9FFFD}]|
       [\\u{A0000}-\\u{AFFFD}]|[\\u{B0000}-\\u{BFFFD}]|[\\u{C0000}-\\u{CFFFD}]|
-      [\\u{D0000}-\\u{DFFFD}]|[\\u{E0000}-\\u{EFFFD}]
+      [\\u{D0000}-\\u{DFFFD}]|[\\u{E1000}-\\u{EFFFD}]
     EOS
     IPRIVATE = Regexp.compile("[\\uE000-\\uF8FF]|[\\u{F0000}-\\u{FFFFD}]|[\\u100000-\\u10FFFD]").freeze
     SCHEME = Regexp.compile("[A-za-z](?:[A-Za-z0-9+-\.])*").freeze
@@ -346,18 +346,7 @@ module RDF
     # @return [Boolean] `true` or `false`
     # @since 0.3.9
     def valid?
-      iriref = StringIO.open do |buffer|
-        to_s.each_char do |u|
-          buffer << case u.ord
-            when (0x00..0x20) then "%%%.2x" % u.ord
-            when 0x3c, 0x3e, 0x22, 0x7b, 0x7d, 0x60, 0x5e, 0x5c # <>"{}`^\\
-              "%%%.2x" % u.ord
-            else u
-          end
-        end
-        buffer.string
-      end
-      iriref.match(RDF::URI::IRI)
+      to_s.match(RDF::URI::IRI) || false
     end
 
     ##

--- a/lib/rdf/ntriples/reader.rb
+++ b/lib/rdf/ntriples/reader.rb
@@ -32,10 +32,10 @@ module RDF::NTriples
     format RDF::NTriples::Format
 
     # @see http://www.w3.org/TR/rdf-testcases/#ntrip_strings
-    ESCAPE_CHARS          = ["\b", "\f", "\t", "\n", "\r", "\"", "\\"].freeze
-    ESCAPE_CHAR4          = /\\u([0-9A-Fa-f]{4,4})/.freeze
-    ESCAPE_CHAR8          = /\\U([0-9A-Fa-f]{8,8})/.freeze
-    ESCAPE_CHAR           = Regexp.union(ESCAPE_CHAR4, ESCAPE_CHAR8).freeze
+    ESCAPE_CHARS    = ["\b", "\f", "\t", "\n", "\r", "\"", "\\"].freeze
+    UCHAR4          = /\\u([0-9A-Fa-f]{4,4})/.freeze
+    UCHAR8          = /\\U([0-9A-Fa-f]{8,8})/.freeze
+    UCHAR           = Regexp.union(UCHAR4, UCHAR8).freeze
 
 
     # Terminals from rdf-turtle.
@@ -51,7 +51,7 @@ module RDF::NTriples
                          [\\uF900-\\uFDCF]|[\\uFDF0-\\uFFFD]|[\\u{10000}-\\u{EFFFF}]
                        EOS
     U_CHARS2         = Regexp.compile("\\u00B7|[\\u0300-\\u036F]|[\\u203F-\\u2040]").freeze
-    IRI_RANGE        = Regexp.compile("[[^<>\"{}][`\\\\^]&&[^\\x00-\\x20]]").freeze
+    IRI_RANGE        = Regexp.compile("[[^<>\"{}\|\^`\\\\]&&[^\\x00-\\x20]]").freeze
 
     # 163s
     PN_CHARS_BASE        = /[A-Z]|[a-z]|#{U_CHARS1}/.freeze
@@ -62,13 +62,13 @@ module RDF::NTriples
     # 159s
     ECHAR                = /\\[tbnrf\\"]/.freeze
     # 18
-    IRIREF               = /<((?:#{IRI_RANGE}|#{ESCAPE_CHAR})*)>/.freeze
+    IRIREF               = /<((?:#{IRI_RANGE}|#{UCHAR})*)>/.freeze
     # 141s
     BLANK_NODE_LABEL     = /_:((?:[0-9]|#{PN_CHARS_U})(?:(?:#{PN_CHARS}|\.)*#{PN_CHARS})?)/.freeze
     # 144s
     LANGTAG              = /@([a-zA-Z]+(?:-[a-zA-Z0-9]+)*)/.freeze
     # 22
-    STRING_LITERAL_QUOTE = /"((?:[^\"\\\n\r]|#{ECHAR}|#{ESCAPE_CHAR})*)"/.freeze
+    STRING_LITERAL_QUOTE = /"((?:[^\"\\\n\r]|#{ECHAR}|#{UCHAR})*)"/.freeze
 
     # @see http://www.w3.org/TR/rdf-testcases/#ntrip_grammar
     COMMENT               = /^#\s*(.*)$/.freeze
@@ -89,57 +89,59 @@ module RDF::NTriples
     # representation.
     #
     # @param  [String] input
+    # @param [{Symbol => Object}] options
+    #   From {RDF::Reader#initialize}
     # @return [RDF::Term]
-    def self.unserialize(input)
+    def self.unserialize(input, options = {})
       case input
         when nil then nil
-        else self.new(input, logger: []).read_value
+        else self.new(input, {logger: []}.merge(options)).read_value
       end
     end
 
     ##
-    # @param  [String] input
+    # (see unserialize)
     # @return [RDF::Resource]
-    def self.parse_subject(input)
-      parse_uri(input) || parse_node(input)
+    def self.parse_subject(input, options = {})
+      parse_uri(input, options) || parse_node(input, options)
     end
 
     ##
-    # @param  [String] input
+    # (see unserialize)
     # @return [RDF::URI]
-    def self.parse_predicate(input)
+    def self.parse_predicate(input, options = {})
       parse_uri(input, intern: true)
     end
 
     ##
-    # @param  [String] input
-    # @return [RDF::Term]
-    def self.parse_object(input)
-      parse_uri(input) || parse_node(input) || parse_literal(input)
+    # (see unserialize)
+    def self.parse_object(input, options = {})
+      parse_uri(input, options) || parse_node(input, options) || parse_literal(input, options)
     end
 
     ##
-    # @param  [String] input
+    # (see unserialize)
     # @return [RDF::Node]
-    def self.parse_node(input)
+    def self.parse_node(input, options = {})
       if input =~ NODEID
         RDF::Node.new($1)
       end
     end
 
     ##
-    # @param  [String] input
+    # (see unserialize)
     # @return [RDF::URI]
     def self.parse_uri(input, options = {})
       if input =~ URIREF
-        RDF::URI.send(options[:intern] ? :intern : :new, $1)
+        uri_str = unescape($1)
+        RDF::URI.send(options[:intern] ? :intern : :new, unescape($1))
       end
     end
 
     ##
-    # @param  [String] input
+    # (see unserialize)
     # @return [RDF::Literal]
-    def self.parse_literal(input)
+    def self.parse_literal(input, options = {})
       case input
         when LITERAL_WITH_LANGUAGE
           RDF::Literal.new(unescape($1), language: $4)
@@ -163,7 +165,7 @@ module RDF::NTriples
       ESCAPE_CHARS.each { |escape| string.gsub!(escape.inspect[1...-1], escape) }
 
       # Decode \uXXXX and \UXXXXXXXX code points:
-      string.gsub!(ESCAPE_CHAR) do
+      string.gsub!(UCHAR) do
         [($1 || $2).hex].pack('U*')
       end
 

--- a/lib/rdf/ntriples/reader.rb
+++ b/lib/rdf/ntriples/reader.rb
@@ -51,7 +51,7 @@ module RDF::NTriples
                          [\\uF900-\\uFDCF]|[\\uFDF0-\\uFFFD]|[\\u{10000}-\\u{EFFFF}]
                        EOS
     U_CHARS2         = Regexp.compile("\\u00B7|[\\u0300-\\u036F]|[\\u203F-\\u2040]").freeze
-    IRI_RANGE        = Regexp.compile("[[^<>\"{}|^`\\\\]&&[^\\x00-\\x20]]").freeze
+    IRI_RANGE        = Regexp.compile("[[^<>\"{}][`\\\\^]&&[^\\x00-\\x20]]").freeze
 
     # 163s
     PN_CHARS_BASE        = /[A-Z]|[a-z]|#{U_CHARS1}/.freeze

--- a/lib/rdf/ntriples/reader.rb
+++ b/lib/rdf/ntriples/reader.rb
@@ -36,9 +36,6 @@ module RDF::NTriples
     ESCAPE_CHAR4          = /\\u([0-9A-Fa-f]{4,4})/.freeze
     ESCAPE_CHAR8          = /\\U([0-9A-Fa-f]{8,8})/.freeze
     ESCAPE_CHAR           = Regexp.union(ESCAPE_CHAR4, ESCAPE_CHAR8).freeze
-    ESCAPE_SURROGATE      = /\\u([0-9A-Fa-f]{4,4})\\u([0-9A-Fa-f]{4,4})/.freeze
-    ESCAPE_SURROGATE1     = (0xD800..0xDBFF).freeze
-    ESCAPE_SURROGATE2     = (0xDC00..0xDFFF).freeze
 
 
     # Terminals from rdf-turtle.

--- a/lib/rdf/ntriples/writer.rb
+++ b/lib/rdf/ntriples/writer.rb
@@ -43,7 +43,7 @@ module RDF::NTriples
 
     # @see http://www.w3.org/TR/rdf-testcases/#ntrip_strings
     ESCAPE_PLAIN = /\A[\x20-\x21\x23-#{Regexp.escape '['}#{Regexp.escape ']'}-\x7E]*\z/m.freeze
-    ESCAPE_PLAIN_U = /\A(?:#{Reader::IRI_RANGE}|#{Reader::ESCAPE_CHAR})*\z/.freeze
+    ESCAPE_PLAIN_U = /\A(?:#{Reader::IRI_RANGE}|#{Reader::UCHAR})*\z/.freeze
 
     ##
     # Escape Literal and URI content. If encoding is ASCII, all unicode
@@ -265,7 +265,7 @@ module RDF::NTriples
             string.each_char do |u|
               buffer << case u.ord
                 when (0x00..0x20) then self.class.escape_utf16(u)
-                when 0x3c, 0x3e, 0x22, 0x7b, 0x7d # <>"{}
+                when 0x22, 0x3c, 0x3e, 0x5c, 0x5e, 0x60, 0x7b, 0x7c, 0x7d # <>"{}|`\
                   self.class.escape_utf16(u)
                 else u
               end
@@ -279,7 +279,7 @@ module RDF::NTriples
             string.each_byte do |u|
               buffer << case u
                 when (0x00..0x20) then self.class.escape_utf16(u)
-                when 0x3c, 0x3e, 0x22, 0x7b, 0x7d # <>"{}
+                when 0x22, 0x3c, 0x3e, 0x5c, 0x5e, 0x60, 0x7b, 0x7c, 0x7d # <>"{}|`\
                   self.class.escape_utf16(u)
                 when (0x80..0xFFFF)                then self.class.escape_utf16(u)
                 when (0x10000..0x10FFFF)           then self.class.escape_utf32(u)

--- a/lib/rdf/util/logger.rb
+++ b/lib/rdf/util/logger.rb
@@ -57,7 +57,7 @@ module RDF; module Util
     ##
     # Used for non-fatal errors where processing can continue. If `logger` is not configured, it logs to `$stderr`.
     #
-    # As a side-effect of setting `@logger_in_error`, which will suppress further error messages until cleared using {#recover}.
+    # As a side-effect of setting `@logger_in_error`, which will suppress further error messages until cleared using {#log_recover}.
     #
     # @overload log_error(*args, options = {}, &block)
     #   @param [Array<String>] args
@@ -192,15 +192,16 @@ module RDF; module Util
     #
     # The call is ignored, unless `@logger` or `@options[:logger]` is set, in which case it records tracing information as indicated.
     #
-    # @param [Array<String>] args Messages
-    # @param [Hash{Symbol => Object}] options
-    # @option options [Integer] :depth
-    #   Recursion depth for indenting output
-    # @option options [:fatal, :error, :warn, :info, :debug] level (:<<)
-    # @option options [Integer] :lineno associated with message
-    # @option options [Logger, #<<] :logger
-    # @yieldreturn [String] added to message
-    # @return [void]
+    # @overload logger_common(args, options)
+    #   @param [Array<String>] args Messages
+    #   @param [Hash{Symbol => Object}] options
+    #   @option options [Integer] :depth
+    #     Recursion depth for indenting output
+    #   @option options [:fatal, :error, :warn, :info, :debug] level (:<<)
+    #   @option options [Integer] :lineno associated with message
+    #   @option options [Logger, #<<] :logger
+    #   @yieldreturn [String] added to message
+    #   @return [void]
     def logger_common(*args)
       options = args.last.is_a?(Hash) ? args.pop : {}
       level = options[:level]

--- a/spec/model_statement_spec.rb
+++ b/spec/model_statement_spec.rb
@@ -239,13 +239,17 @@ describe RDF::Statement do
       RDF::Statement.new(RDF::Node("node"), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => true,
       RDF::Statement.new(RDF::URI("http://rubygems.org/gems/rdf"), RDF::URI("http://purl.org/dc/terms/creator"), RDF::Node("node")) => true,
       RDF::Statement.new(RDF::URI("http://rubygems.org/gems/rdf"), RDF::URI("http://purl.org/dc/terms/creator"), RDF::Literal("literal")) => true,
-      RDF::Statement.new(RDF::URI('file:///path/to/file with spaces.txt'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => false,
+      RDF::Statement.new(RDF::URI('file:///path/to/file with spaces.txt'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => true,
       RDF::Statement.new(nil, RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => false,
       RDF::Statement.new(RDF::URI("http://rubygems.org/gems/rdf"), nil, RDF::URI("http://ar.to/#self")) => false,
       RDF::Statement.new(RDF::URI("http://rubygems.org/gems/rdf"), RDF::URI("http://purl.org/dc/terms/creator"), nil) => false,
       RDF::Statement.new(RDF::Literal("literal"), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => false,
       RDF::Statement.new(RDF::URI("http://rubygems.org/gems/rdf"), RDF::Node("node"), RDF::URI("http://ar.to/#self")) => false,
       RDF::Statement.new(RDF::URI("http://rubygems.org/gems/rdf"), RDF::Literal("literal"), RDF::URI("http://ar.to/#self")) => false,
+      RDF::Statement.new(RDF::URI('scheme://auth/\\u0000'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => true,
+      RDF::Statement.new(RDF::URI('scheme://auth/^'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => true,
+      RDF::Statement.new(RDF::URI('scheme://auth/`'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => true,
+      RDF::Statement.new(RDF::URI('scheme://auth/\\'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => true,
     }.each do |st, valid|
       context "given #{st}" do
         if valid

--- a/spec/model_statement_spec.rb
+++ b/spec/model_statement_spec.rb
@@ -239,17 +239,17 @@ describe RDF::Statement do
       RDF::Statement.new(RDF::Node("node"), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => true,
       RDF::Statement.new(RDF::URI("http://rubygems.org/gems/rdf"), RDF::URI("http://purl.org/dc/terms/creator"), RDF::Node("node")) => true,
       RDF::Statement.new(RDF::URI("http://rubygems.org/gems/rdf"), RDF::URI("http://purl.org/dc/terms/creator"), RDF::Literal("literal")) => true,
-      RDF::Statement.new(RDF::URI('file:///path/to/file with spaces.txt'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => true,
+      RDF::Statement.new(RDF::URI('file:///path/to/file with spaces.txt'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => false,
       RDF::Statement.new(nil, RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => false,
       RDF::Statement.new(RDF::URI("http://rubygems.org/gems/rdf"), nil, RDF::URI("http://ar.to/#self")) => false,
       RDF::Statement.new(RDF::URI("http://rubygems.org/gems/rdf"), RDF::URI("http://purl.org/dc/terms/creator"), nil) => false,
       RDF::Statement.new(RDF::Literal("literal"), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => false,
       RDF::Statement.new(RDF::URI("http://rubygems.org/gems/rdf"), RDF::Node("node"), RDF::URI("http://ar.to/#self")) => false,
       RDF::Statement.new(RDF::URI("http://rubygems.org/gems/rdf"), RDF::Literal("literal"), RDF::URI("http://ar.to/#self")) => false,
-      RDF::Statement.new(RDF::URI('scheme://auth/\\u0000'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => true,
-      RDF::Statement.new(RDF::URI('scheme://auth/^'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => true,
-      RDF::Statement.new(RDF::URI('scheme://auth/`'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => true,
-      RDF::Statement.new(RDF::URI('scheme://auth/\\'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => true,
+      RDF::Statement.new(RDF::URI('scheme://auth/\\u0000'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => false,
+      RDF::Statement.new(RDF::URI('scheme://auth/^'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => false,
+      RDF::Statement.new(RDF::URI('scheme://auth/`'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => false,
+      RDF::Statement.new(RDF::URI('scheme://auth/\\'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => false,
     }.each do |st, valid|
       context "given #{st}" do
         if valid

--- a/spec/model_uri_spec.rb
+++ b/spec/model_uri_spec.rb
@@ -256,10 +256,8 @@ describe RDF::URI do
 
     describe "#valid?" do
       let(:refs) {
-        %W(a d z A D Z 0 5 99 - . _ ~ ` ^ \\ \u0053 \u00D6 foo %20) +
-        %W(\u0000 \u0001 \u0002 \u0003 \u0004 \u0005 \u0006
-           \u0010 \u0020 \u003c \u003e \u0022 \u007b \u007d) +
-        %W(Dürst)
+        %W(a d z A D Z 0 5 99 - . _ ~ \u0053 \u00D6 foo %20) +
+        %W(\U00000053 Dürst)
       }
       {
         ""  => "%s",
@@ -324,9 +322,11 @@ describe RDF::URI do
         end
       end
 
-      [" ", "<", ">", "'", '"'].each do |c|
-        it "validates <http://example/#{c}>" do
-          expect(RDF::URI("http://example/#{c}")).to be_valid
+      %W(` ^ \\ \u0000 \u0001 \u0002 \u0003 \u0004 \u0005 \u0006
+         \u0010 \u0020 \u003c \u003e \u0022 \u007b \u007d) +
+      [" ", "<", ">", "'" '"'].each do |c|
+        it "does not validate <http://example/#{c}>" do
+          expect(RDF::URI("http://example/#{c}")).not_to be_valid
         end
       end
     end

--- a/spec/model_uri_spec.rb
+++ b/spec/model_uri_spec.rb
@@ -256,8 +256,10 @@ describe RDF::URI do
 
     describe "#valid?" do
       let(:refs) {
-        %W(a d z A D Z 0 5 99 - . _ ~ \u0053 \u00D6 foo %20) +
-        %W(\U00000053 Dürst)
+        %W(a d z A D Z 0 5 99 - . _ ~ ` ^ \\ \u0053 \u00D6 foo %20) +
+        %W(\u0000 \u0001 \u0002 \u0003 \u0004 \u0005 \u0006
+           \u0010 \u0020 \u003c \u003e \u0022 \u007b \u007d) +
+        %W(Dürst)
       }
       {
         ""  => "%s",
@@ -321,10 +323,10 @@ describe RDF::URI do
           end
         end
       end
-      
-      [" ", "<", ">", "'" '"'].each do |c|
-        it "does not validate <http://example/#{c}>" do
-          expect(RDF::URI("http://example/#{c}")).not_to be_valid
+
+      [" ", "<", ">", "'", '"'].each do |c|
+        it "validates <http://example/#{c}>" do
+          expect(RDF::URI("http://example/#{c}")).to be_valid
         end
       end
     end

--- a/spec/nquads_spec.rb
+++ b/spec/nquads_spec.rb
@@ -298,7 +298,7 @@ describe RDF::NQuads::Writer do
       RDF::Statement.new(RDF::Node("node"), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self"), graph_name: RDF.to_uri) => true,
       RDF::Statement.new(RDF::URI("http://rubygems.org/gems/rdf"), RDF::URI("http://purl.org/dc/terms/creator"), RDF::Node("node"), graph_name: RDF.to_uri) => true,
       RDF::Statement.new(RDF::URI("http://rubygems.org/gems/rdf"), RDF::URI("http://purl.org/dc/terms/creator"), RDF::Literal("literal"), graph_name: RDF.to_uri) => true,
-      RDF::Statement.new(RDF::URI('file:///path/to/file with spaces.txt'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self"), graph_name: RDF.to_uri) => false,
+      RDF::Statement.new(RDF::URI('file:///path/to/file with spaces.txt'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self"), graph_name: RDF.to_uri) => true,
       RDF::Statement.new(nil, RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self"), graph_name: RDF.to_uri) => false,
       RDF::Statement.new(RDF::URI("http://rubygems.org/gems/rdf"), nil, RDF::URI("http://ar.to/#self"), graph_name: RDF.to_uri) => false,
       RDF::Statement.new(RDF::URI("http://rubygems.org/gems/rdf"), RDF::URI("http://purl.org/dc/terms/creator"), nil, graph_name: RDF.to_uri) => false,
@@ -306,6 +306,10 @@ describe RDF::NQuads::Writer do
       RDF::Statement.new(RDF::URI("http://rubygems.org/gems/rdf"), RDF::Node("node"), RDF::URI("http://ar.to/#self"), graph_name: RDF.to_uri) => false,
       RDF::Statement.new(RDF::URI("http://rubygems.org/gems/rdf"), RDF::Literal("literal"), RDF::URI("http://ar.to/#self"), graph_name: RDF.to_uri) => false,
       RDF::Statement.new(RDF::URI("http://rubygems.org/gems/rdf"), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self"), graph_name: RDF::Literal("literal")) => false,
+      RDF::Statement.new(RDF::URI('scheme://auth/\\u0000'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => true,
+      RDF::Statement.new(RDF::URI('scheme://auth/^'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self"), graph_name: RDF.to_uri) => true,
+      RDF::Statement.new(RDF::URI('scheme://auth/`'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self"), graph_name: RDF.to_uri) => true,
+      RDF::Statement.new(RDF::URI('scheme://auth/\\'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self"), graph_name: RDF.to_uri) => true,
     }.each do |st, valid|
       include_examples "validation", st, valid
     end

--- a/spec/nquads_spec.rb
+++ b/spec/nquads_spec.rb
@@ -298,7 +298,7 @@ describe RDF::NQuads::Writer do
       RDF::Statement.new(RDF::Node("node"), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self"), graph_name: RDF.to_uri) => true,
       RDF::Statement.new(RDF::URI("http://rubygems.org/gems/rdf"), RDF::URI("http://purl.org/dc/terms/creator"), RDF::Node("node"), graph_name: RDF.to_uri) => true,
       RDF::Statement.new(RDF::URI("http://rubygems.org/gems/rdf"), RDF::URI("http://purl.org/dc/terms/creator"), RDF::Literal("literal"), graph_name: RDF.to_uri) => true,
-      RDF::Statement.new(RDF::URI('file:///path/to/file with spaces.txt'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self"), graph_name: RDF.to_uri) => true,
+      RDF::Statement.new(RDF::URI('file:///path/to/file with spaces.txt'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self"), graph_name: RDF.to_uri) => false,
       RDF::Statement.new(nil, RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self"), graph_name: RDF.to_uri) => false,
       RDF::Statement.new(RDF::URI("http://rubygems.org/gems/rdf"), nil, RDF::URI("http://ar.to/#self"), graph_name: RDF.to_uri) => false,
       RDF::Statement.new(RDF::URI("http://rubygems.org/gems/rdf"), RDF::URI("http://purl.org/dc/terms/creator"), nil, graph_name: RDF.to_uri) => false,
@@ -306,10 +306,10 @@ describe RDF::NQuads::Writer do
       RDF::Statement.new(RDF::URI("http://rubygems.org/gems/rdf"), RDF::Node("node"), RDF::URI("http://ar.to/#self"), graph_name: RDF.to_uri) => false,
       RDF::Statement.new(RDF::URI("http://rubygems.org/gems/rdf"), RDF::Literal("literal"), RDF::URI("http://ar.to/#self"), graph_name: RDF.to_uri) => false,
       RDF::Statement.new(RDF::URI("http://rubygems.org/gems/rdf"), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self"), graph_name: RDF::Literal("literal")) => false,
-      RDF::Statement.new(RDF::URI('scheme://auth/\\u0000'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => true,
-      RDF::Statement.new(RDF::URI('scheme://auth/^'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self"), graph_name: RDF.to_uri) => true,
-      RDF::Statement.new(RDF::URI('scheme://auth/`'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self"), graph_name: RDF.to_uri) => true,
-      RDF::Statement.new(RDF::URI('scheme://auth/\\'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self"), graph_name: RDF.to_uri) => true,
+      RDF::Statement.new(RDF::URI('scheme://auth/\\u0000'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => false,
+      RDF::Statement.new(RDF::URI('scheme://auth/^'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self"), graph_name: RDF.to_uri) => false,
+      RDF::Statement.new(RDF::URI('scheme://auth/`'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self"), graph_name: RDF.to_uri) => false,
+      RDF::Statement.new(RDF::URI('scheme://auth/\\'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self"), graph_name: RDF.to_uri) => false,
     }.each do |st, valid|
       include_examples "validation", st, valid
     end

--- a/spec/ntriples_spec.rb
+++ b/spec/ntriples_spec.rb
@@ -253,13 +253,17 @@ describe RDF::NTriples::Writer do
       RDF::Statement.new(RDF::Node("node"), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => true,
       RDF::Statement.new(RDF::URI("http://rubygems.org/gems/rdf"), RDF::URI("http://purl.org/dc/terms/creator"), RDF::Node("node")) => true,
       RDF::Statement.new(RDF::URI("http://rubygems.org/gems/rdf"), RDF::URI("http://purl.org/dc/terms/creator"), RDF::Literal("literal")) => true,
-      RDF::Statement.new(RDF::URI('file:///path/to/file with spaces.txt'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => false,
+      RDF::Statement.new(RDF::URI('file:///path/to/file with spaces.txt'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => true,
       RDF::Statement.new(nil, RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => false,
       RDF::Statement.new(RDF::URI("http://rubygems.org/gems/rdf"), nil, RDF::URI("http://ar.to/#self")) => false,
       RDF::Statement.new(RDF::URI("http://rubygems.org/gems/rdf"), RDF::URI("http://purl.org/dc/terms/creator"), nil) => false,
       RDF::Statement.new(RDF::Literal("literal"), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => false,
       RDF::Statement.new(RDF::URI("http://rubygems.org/gems/rdf"), RDF::Node("node"), RDF::URI("http://ar.to/#self")) => false,
       RDF::Statement.new(RDF::URI("http://rubygems.org/gems/rdf"), RDF::Literal("literal"), RDF::URI("http://ar.to/#self")) => false,
+      RDF::Statement.new(RDF::URI('scheme://auth/\\u0000'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => true,
+      RDF::Statement.new(RDF::URI('scheme://auth/^'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => true,
+      RDF::Statement.new(RDF::URI('scheme://auth/`'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => true,
+      RDF::Statement.new(RDF::URI('scheme://auth/\\'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => true,
     }.each do |st, valid|
       include_examples "validation", st, valid
     end
@@ -624,10 +628,11 @@ describe RDF::NTriples do
       end
     end
 
-    describe "with URI i18n URIs" do
+    describe "with i18n URIs" do
       {
         %(<http://a/b#Dürst> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> "URI straight in UTF8".) => %(<http://a/b#D\\u00FCrst> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> "URI straight in UTF8" .),
         %(<http://a/b#a> <http://a/b#related> <http://a/b#\u3072\u3089\u304C\u306A>.) => %(<http://a/b#a> <http://a/b#related> <http://a/b#\\u3072\\u3089\\u304C\\u306A> .),
+        %(<scheme://auth/\\u0020> <http://example.org/p> <http://example.org/o>.) => %(<scheme://auth/\\u0020> <http://example.org/p> <http://example.org/o> .),
       }.each_pair do |src, res|
         specify src do
           stmt1 = reader.unserialize(src)

--- a/spec/ntriples_spec.rb
+++ b/spec/ntriples_spec.rb
@@ -253,17 +253,17 @@ describe RDF::NTriples::Writer do
       RDF::Statement.new(RDF::Node("node"), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => true,
       RDF::Statement.new(RDF::URI("http://rubygems.org/gems/rdf"), RDF::URI("http://purl.org/dc/terms/creator"), RDF::Node("node")) => true,
       RDF::Statement.new(RDF::URI("http://rubygems.org/gems/rdf"), RDF::URI("http://purl.org/dc/terms/creator"), RDF::Literal("literal")) => true,
-      RDF::Statement.new(RDF::URI('file:///path/to/file with spaces.txt'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => true,
+      RDF::Statement.new(RDF::URI('file:///path/to/file with spaces.txt'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => false,
       RDF::Statement.new(nil, RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => false,
       RDF::Statement.new(RDF::URI("http://rubygems.org/gems/rdf"), nil, RDF::URI("http://ar.to/#self")) => false,
       RDF::Statement.new(RDF::URI("http://rubygems.org/gems/rdf"), RDF::URI("http://purl.org/dc/terms/creator"), nil) => false,
       RDF::Statement.new(RDF::Literal("literal"), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => false,
       RDF::Statement.new(RDF::URI("http://rubygems.org/gems/rdf"), RDF::Node("node"), RDF::URI("http://ar.to/#self")) => false,
       RDF::Statement.new(RDF::URI("http://rubygems.org/gems/rdf"), RDF::Literal("literal"), RDF::URI("http://ar.to/#self")) => false,
-      RDF::Statement.new(RDF::URI('scheme://auth/\\u0000'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => true,
-      RDF::Statement.new(RDF::URI('scheme://auth/^'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => true,
-      RDF::Statement.new(RDF::URI('scheme://auth/`'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => true,
-      RDF::Statement.new(RDF::URI('scheme://auth/\\'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => true,
+      RDF::Statement.new(RDF::URI('scheme://auth/\\u0000'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => false,
+      RDF::Statement.new(RDF::URI('scheme://auth/^'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => false,
+      RDF::Statement.new(RDF::URI('scheme://auth/`'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => false,
+      RDF::Statement.new(RDF::URI('scheme://auth/\\'), RDF::URI("http://purl.org/dc/terms/creator"), RDF::URI("http://ar.to/#self")) => false,
     }.each do |st, valid|
       include_examples "validation", st, valid
     end
@@ -632,14 +632,14 @@ describe RDF::NTriples do
       {
         %(<http://a/b#Dürst> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> "URI straight in UTF8".) => %(<http://a/b#D\\u00FCrst> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> "URI straight in UTF8" .),
         %(<http://a/b#a> <http://a/b#related> <http://a/b#\u3072\u3089\u304C\u306A>.) => %(<http://a/b#a> <http://a/b#related> <http://a/b#\\u3072\\u3089\\u304C\\u306A> .),
-        %(<scheme://auth/\\u0020> <http://example.org/p> <http://example.org/o>.) => %(<scheme://auth/\\u0020> <http://example.org/p> <http://example.org/o> .),
+        %(<scheme://auth/\u0020> <http://example.org/p> <http://example.org/o>.) => %(<scheme://auth/\\u0020> <http://example.org/p> <http://example.org/o> .),
         %(<scheme://auth/`> <http://example.org/p> <http://example.org/o>.) => %(<scheme://auth/\\u0060> <http://example.org/p> <http://example.org/o> .),
         %(<scheme://auth/^> <http://example.org/p> <http://example.org/o>.) => %(<scheme://auth/\\u005e> <http://example.org/p> <http://example.org/o> .),
         %(<scheme://auth/\\> <http://example.org/p> <http://example.org/o>.) => %(<scheme://auth/\\u005c> <http://example.org/p> <http://example.org/o> .),
       }.each_pair do |src, res|
         specify src do
-          stmt1 = reader.unserialize(src)
-          stmt2 = reader.unserialize(res)
+          stmt1 = reader.unserialize(src, validate: false)
+          stmt2 = reader.unserialize(res, validate: true)
           expect(stmt1).to eq stmt2
         end
       end

--- a/spec/ntriples_spec.rb
+++ b/spec/ntriples_spec.rb
@@ -633,6 +633,9 @@ describe RDF::NTriples do
         %(<http://a/b#Dürst> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> "URI straight in UTF8".) => %(<http://a/b#D\\u00FCrst> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> "URI straight in UTF8" .),
         %(<http://a/b#a> <http://a/b#related> <http://a/b#\u3072\u3089\u304C\u306A>.) => %(<http://a/b#a> <http://a/b#related> <http://a/b#\\u3072\\u3089\\u304C\\u306A> .),
         %(<scheme://auth/\\u0020> <http://example.org/p> <http://example.org/o>.) => %(<scheme://auth/\\u0020> <http://example.org/p> <http://example.org/o> .),
+        %(<scheme://auth/`> <http://example.org/p> <http://example.org/o>.) => %(<scheme://auth/\\u0060> <http://example.org/p> <http://example.org/o> .),
+        %(<scheme://auth/^> <http://example.org/p> <http://example.org/o>.) => %(<scheme://auth/\\u005e> <http://example.org/p> <http://example.org/o> .),
+        %(<scheme://auth/\\> <http://example.org/p> <http://example.org/o>.) => %(<scheme://auth/\\u005c> <http://example.org/p> <http://example.org/o> .),
       }.each_pair do |src, res|
         specify src do
           stmt1 = reader.unserialize(src)


### PR DESCRIPTION
* URI escaping was wrong. Updated `#to_base` to use `NTriples::Writer.serialize`.
* `NTriples::Writer#format_uri` no repeats logic of `escape` for specific character ranges allowed in NTriples IRIREF, with provision for ASCII-only escaping.
* `URI#valid?` turns allowed characters into %-encoded before checking for valid.
* Fixed `NTriples::Reader#IRI_RANGE` to correctly detect use of "\`^\\" in URIs.

@bendiken, @no_reply, can I get a sanity check?