### PR TITLE
Fix a typo (`Enummerable`) in `RDF::Mutable`

### DIFF
--- a/lib/rdf/mixin/mutable.rb
+++ b/lib/rdf/mixin/mutable.rb
@@ -122,7 +122,7 @@ module RDF
     #   @return [self]
     def update(*statements)
       raise TypeError.new("#{self} is immutable") if immutable?
-      statements = statements[0] if statements.length == 1 && statements[0].is_a?(Enummerable)
+      statements = statements[0] if statements.length == 1 && statements[0].is_a?(Enumerable)
 
       statements.each do |statement|
         if (statement = Statement.from(statement))


### PR DESCRIPTION
This was introduced in 22d6fea51, leading up to the 1.99 release.

This conditional is apparently untested; apparently we never try to
`#update` on a single statement throughout the suite. I'm working on a
test to catch this.

I believe we should merge this immediately, since it is a simple typo
fix. Any issues revealed in adding `#update` testing can be dealt with
as an issue unrelated to the typo.