### PR TITLE
Transaction

### DIFF
--- a/lib/rdf/changeset.rb
+++ b/lib/rdf/changeset.rb
@@ -1,9 +1,33 @@
 module RDF
   ##
-  # An RDF changeset.
+  # An RDF changeset that can be applied to an {RDF::Mutable}.
   #
   # Changesets consist of a sequence of RDF statements to delete from and a
-  # sequence of RDF statements to insert into a target dataset.
+  # sequence of RDF statements to insert into a target dataset. 
+  # 
+  # @example Applying a Changeset with block syntax
+  #   graph = RDF::Graph.new
+  #   graph << [RDF::URI('s_del'), RDF::URI('p_del'), RDF::URI('o_del')]
+  #
+  #   RDF::Changeset.apply(graph) do |c|
+  #     c.insert [RDF::URI('s1'), RDF::URI('p1'), RDF::URI('o1')]
+  #     c.insert [RDF::URI('s2'), RDF::URI('p2'), RDF::URI('o2')]
+  #     c.delete [RDF::URI('s_del'), RDF::URI('p_del'), RDF::URI('o_del')]
+  #   end
+  #
+  # @example Defining a changeset for later application to a Mutable
+  #   changes = RDF::Changeset.new do |c|
+  #     c.insert [RDF::URI('s1'), RDF::URI('p1'), RDF::URI('o1')]
+  #     c.insert [RDF::URI('s2'), RDF::URI('p2'), RDF::URI('o2')]
+  #     c.delete [RDF::URI('s_del'), RDF::URI('p_del'), RDF::URI('o_del')]
+  #   end
+  #
+  #   graph = RDF::Graph.new
+  #   graph << [RDF::URI('s_del'), RDF::URI('p_del'), RDF::URI('o_del')]
+  # 
+  #   changes.apply(graph) # or graph.apply_changeset(changes)
+  #
+  # @note When applying a Changeset, deletes are resolved before inserts.
   #
   # @since 2.0.0
   class Changeset

--- a/lib/rdf/changeset.rb
+++ b/lib/rdf/changeset.rb
@@ -87,6 +87,12 @@ module RDF
     end
 
     ##
+    # @return [Boolean] `true` iff inserts and deletes are both empty
+    def empty?
+      deletes.empty? && inserts.empty?
+    end
+
+    ##
     # Returns a developer-friendly representation of this changeset.
     #
     # @return [String]

--- a/lib/rdf/mixin/enumerable.rb
+++ b/lib/rdf/mixin/enumerable.rb
@@ -70,6 +70,7 @@ module RDF
     #   * `:inference` supports RDFS inferrence of queryable contents.
     #   * `:validity` allows a concrete Enumerable implementation to indicate that it does or does not support valididty checking. By default implementations are assumed to support validity checking.
     #   * `:skolemize` supports [Skolemization](https://www.w3.org/wiki/BnodeSkolemization) of an `Enumerable`. Implementations supporting this feature must implement a `#skolemize` method, taking a base URI used for minting URIs for BNodes as stable identifiers and a `#deskolemize` method, also taking a base URI used for turning URIs having that prefix back into the same BNodes which were originally skolemized.
+    #   * `:transactions` supports atomic application of a [Changeset] 
     #
     # @param  [Symbol, #to_sym] feature
     # @return [Boolean]

--- a/lib/rdf/mixin/enumerable.rb
+++ b/lib/rdf/mixin/enumerable.rb
@@ -70,7 +70,7 @@ module RDF
     #   * `:inference` supports RDFS inferrence of queryable contents.
     #   * `:validity` allows a concrete Enumerable implementation to indicate that it does or does not support valididty checking. By default implementations are assumed to support validity checking.
     #   * `:skolemize` supports [Skolemization](https://www.w3.org/wiki/BnodeSkolemization) of an `Enumerable`. Implementations supporting this feature must implement a `#skolemize` method, taking a base URI used for minting URIs for BNodes as stable identifiers and a `#deskolemize` method, also taking a base URI used for turning URIs having that prefix back into the same BNodes which were originally skolemized.
-    #   * `:transactions` supports atomic application of a [Changeset] 
+    #   * `:transactions` supports atomic transactions
     #
     # @param  [Symbol, #to_sym] feature
     # @return [Boolean]

--- a/lib/rdf/mixin/mutable.rb
+++ b/lib/rdf/mixin/mutable.rb
@@ -202,8 +202,8 @@ module RDF
     # Applies the given changeset
     #
     # If `#supports?(:transactions)` is `true`, this must apply the changeset
-    # atomically. Otherwise, it should offer an efficient implementation for the
-    # `Enumerable` subclass.
+    # atomically. Otherwise, it should offer an efficient implementation of a 
+    # combined delete/insert of the changeset.
     #
     # @param changeset [RDF::Changeset] the changeset to apply
     # @return [Boolean] true if the changeset has been applied

--- a/lib/rdf/mixin/mutable.rb
+++ b/lib/rdf/mixin/mutable.rb
@@ -199,6 +199,19 @@ module RDF
     alias_method :delete_insert!, :delete_insert
 
     ##
+    # Applies the given changeset
+    #
+    # If `#supports?(:transactions)` is `true`, this must apply the changeset
+    # atomically. Otherwise, it should offer an efficient implementation for the
+    # `Enumerable` subclass.
+    #
+    # @param changeset [RDF::Changeset] the changeset to apply
+    # @return [Boolean] true if the changeset has been applied
+    def apply_changeset(changeset)
+      delete_insert(changeset.deletes, changeset.inserts)
+    end
+
+    ##
     # Deletes all RDF statements from `self`.
     #
     # @raise  [TypeError] if `self` is immutable

--- a/lib/rdf/repository.rb
+++ b/lib/rdf/repository.rb
@@ -153,17 +153,16 @@ module RDF
     #     tx.insert [RDF::URI("http://rubygems.org/gems/rdf"), RDF::RDFS.label, "RDF.rb"]
     #   end
     #
-    # @param  [RDF::Resource] graph_name
-    #   Graph name on which to run the transaction, use `false` for the default
-    #   graph_name and `nil` the entire Repository
+    # @param mutable [Boolean] 
+    #   Context on which to run the transaction, use `false` for the default
     # @yield  [tx]
     # @yieldparam  [RDF::Transaction] tx
     # @yieldreturn [void] ignored
     # @return [self]
     # @see    RDF::Transaction
     # @since  0.3.0
-    def transaction(graph_name = nil, &block)
-      tx = begin_transaction(graph_name)
+    def transaction(mutable: false, &block)
+      tx = begin_transaction(mutable: mutable)
       begin
         case block.arity
           when 1 then block.call(tx)
@@ -190,8 +189,8 @@ module RDF
     # @param  [RDF::Resource] graph_name
     # @return [RDF::Transaction]
     # @since  0.3.0
-    def begin_transaction(graph_name)
-      RDF::Transaction.new(graph: graph_name)
+    def begin_transaction(mutable: false)
+      RDF::Transaction.new(self, mutable: mutable)
     end
 
     ##

--- a/lib/rdf/repository.rb
+++ b/lib/rdf/repository.rb
@@ -108,6 +108,8 @@ module RDF
       @uri     = @options.delete(:uri)
       @title   = @options.delete(:title)
 
+      @tx_class = @options.delete(:transaction_class) { RDF::Transaction }
+
       # Provide a default in-memory implementation:
       send(:extend, Implementation) if self.class.equal?(RDF::Repository)
 
@@ -190,21 +192,17 @@ module RDF
     # @return [RDF::Transaction]
     # @since  0.3.0
     def begin_transaction(mutable: false)
-      RDF::Transaction.new(self, mutable: mutable)
+      @tx_class.new(self, mutable: mutable)
     end
 
     ##
     # Rolls back the given transaction.
     #
-    # Subclasses implementing transaction-capable storage adapters may wish
-    # to override this method in order to roll back the given transaction in
-    # the underlying storage.
-    #
     # @param  [RDF::Transaction] tx
     # @return [void] ignored
     # @since  0.3.0
     def rollback_transaction(tx)
-      # nothing to do
+      tx.rollback
     end
 
     ##

--- a/lib/rdf/repository.rb
+++ b/lib/rdf/repository.rb
@@ -240,6 +240,7 @@ module RDF
         when :graph_name   then @options[:with_graph_name]
         when :inference then false  # forward-chaining inference
         when :validity  then @options.fetch(:with_validity, true)
+        when :snapshots then true
         else false
         end
       end
@@ -314,6 +315,15 @@ module RDF
         enum_statement
       end
       alias_method :each, :each_statement
+      
+      ##
+      # A queryable snapshot of the repository for isolated reads. Used by
+      # `RDF::Transaction` for
+      # 
+      # @return [Queryable] a queryable repository snapshot.
+      def snapshot
+        self.class.new(data: @data).freeze
+      end
 
       protected
 

--- a/lib/rdf/transaction.rb
+++ b/lib/rdf/transaction.rb
@@ -209,7 +209,10 @@ module RDF
     # Executes the transaction
     #
     # @return [Boolean] `true` if the changes are successfully applied.
+    # @raise [TransactionError] if the transaction can't be applied
     def execute
+      raise TransactionError, 'Cannot execute a rolled back transaction. ' \
+                              'Open a new one instead.' if @rolledback
       @changes.apply(@repository)
     end
 
@@ -226,6 +229,7 @@ module RDF
     # @return [Boolean] `true` if the changes are successfully applied.
     def rollback
       @changes = RDF::Changeset.new
+      @rolledback = true
     end
 
     protected
@@ -251,5 +255,11 @@ module RDF
     end
 
     undef_method :load, :update, :clear
+
+    public
+    
+    ##
+    # An error class for transaction failures.
+    class TransactionError < RuntimeError; end
   end # Transaction
 end # RDF

--- a/lib/rdf/transaction.rb
+++ b/lib/rdf/transaction.rb
@@ -52,11 +52,14 @@ module RDF
   # @since 0.3.0
   class Transaction
     include RDF::Mutable
+    include RDF::Enumerable
     include RDF::Queryable
 
-    extend Forwardable
-
-    def_delegators :@snapshot, :query_pattern, :query_execute
+    ##
+    # @see RDF::Enumerable#each
+    def each(*args, &block)
+      @snapshot.each(*args, &block)
+    end
 
     ##
     # Executes a transaction against the given RDF repository.
@@ -122,7 +125,7 @@ module RDF
     # @yieldparam [RDF::Transaction] tx
     def initialize(repository, options = {}, &block)
       @repository = repository
-      @snapsot = 
+      @snapshot = 
         repository.supports?(:snapshots) ? repository.snapshot : repository
       @options  = options.dup
       @mutable  = !!(@options.delete(:mutable) || false)
@@ -251,6 +254,14 @@ module RDF
       @changes.delete(statement)
     end
 
+    def query_pattern(*args, &block)
+      @snapshot.send(:query_pattern, *args, &block)
+    end
+
+    def query_execute(*args, &block)
+      @snapshot.send(:query_execute, *args, &block)
+    end
+  
     undef_method :load, :update, :clear
 
     public

--- a/lib/rdf/transaction.rb
+++ b/lib/rdf/transaction.rb
@@ -41,8 +41,7 @@ module RDF
   # The base class provides a full, buffered implementation depending on 
   # `RDF::Changeset` and using `Changeset#apply`. Custom `Repositories`
   # can implement a minimial write-atomic transactions by overriding
-  # `#apply_changeset`. Minimal snapshot isolation for queries can be 
-  # implemented by passing a `:snapshot` to `options` on initialization.
+  # `#apply_changeset`.
   #
   # For datastores that support Transactions natively, it is recommended 
   # to implement a custom `Transaction` subclass, setting `@tx_class` to
@@ -119,15 +118,13 @@ module RDF
     # @param  [Hash{Symbol => Object}]  options
     # @option options [Boolean]         :mutable (false)
     #    Whether this is a read-only or read/write transaction.
-    # @option options [Queryable]       :snapshot
-    #    A queryable snapshot of the repository for isolated reads. Defaults to
-    #    `#repository` as an unisolated query target.
     # @yield  [tx]
     # @yieldparam [RDF::Transaction] tx
     def initialize(repository, options = {}, &block)
       @repository = repository
+      @snapsot = 
+        repository.supports?(:snapshots) ? repository.snapshot : repository
       @options  = options.dup
-      @snapshot = @options.delete(:snapshot) { @repository }
       @mutable  = !!(@options.delete(:mutable) || false)
       
       @changes = RDF::Changeset.new

--- a/spec/changeset_spec.rb
+++ b/spec/changeset_spec.rb
@@ -76,6 +76,24 @@ describe RDF::Changeset do
     end
   end
 
+  describe '#empty?' do
+    let(:s) {RDF::Statement.new(RDF::URI("s"), RDF::URI("p"), RDF::URI("o"))}
+
+    it 'is empty when no deletes/inserts are present' do
+      expect(subject).to be_empty
+    end
+
+    it 'is not empty when deletes are present' do
+      subject.delete(s)
+      expect(subject).not_to be_empty
+    end
+
+    it 'is not empty when inserts are present' do
+      subject.insert(s)
+      expect(subject).not_to be_empty
+    end
+  end
+
   describe '#delete' do
     let(:s) {RDF::Statement.new(RDF::URI("s"), RDF::URI("p"), RDF::URI("o"))}
 

--- a/spec/changeset_spec.rb
+++ b/spec/changeset_spec.rb
@@ -1,0 +1,112 @@
+require File.join(File.dirname(__FILE__), 'spec_helper')
+
+describe RDF::Changeset do
+  describe "#initialize" do
+    it "accepts inserts" do
+      g = double("inserts")
+      this = described_class.new(insert: g)
+      expect(this.inserts).to eq g
+    end
+
+    it "accepts deletes" do
+      g = double("deletes")
+      this = described_class.new(delete: g)
+      expect(this.deletes).to eq g
+    end
+
+    it "accepts inserts & deletes" do
+      ins = double("inserts")
+      del = double("deletes")
+
+      this = described_class.new(delete: del, insert: ins)
+
+      expect(this.inserts).to eq ins
+      expect(this.deletes).to eq del
+    end
+  end
+
+  its(:deletes) { is_expected.to be_a(RDF::Enumerable) }
+  its(:inserts) { is_expected.to be_a(RDF::Enumerable) }
+
+  it { is_expected.to be_mutable }
+  it { is_expected.to_not be_readable }
+
+  it "does not respond to #load" do
+    expect {subject.load("http://example/")}.to raise_error(NoMethodError)
+  end
+
+  it "does not respond to #update" do
+    expect { subject.update(RDF::Statement.new) }.to raise_error(NoMethodError)
+  end
+
+  it "does not respond to #clear" do
+    expect { subject.clear }.to raise_error(NoMethodError)
+  end
+
+  describe "#apply" do
+    let(:st) { RDF::Statement.new(RDF::URI("s"), RDF::URI("p"), RDF::URI("o")) }
+    
+    context 'on repository' do
+      let(:repo) { RDF::Repository.new }
+
+      it "deletes statements" do
+        repo << st
+        subject.delete(st)
+
+        expect { subject.apply(repo) }.to change { repo.statements }.to be_empty
+      end
+
+      it "inserts statements" do
+        subject.insert(st)
+        expect { subject.apply(repo) }
+          .to change { repo.statements }.to contain_exactly(st)
+      end
+
+      it "inserts & deletes statements" do
+        repo << st
+        new_statement = RDF::Statement(RDF::URI('x'),
+                                       RDF::URI('y'),
+                                       RDF::URI('z'))
+        subject.delete(st)
+        subject.insert(new_statement)
+
+        expect { subject.apply(repo) }
+          .to change { repo.statements }.to contain_exactly(new_statement)
+      end
+    end
+  end
+
+  describe '#delete' do
+    let(:s) {RDF::Statement.new(RDF::URI("s"), RDF::URI("p"), RDF::URI("o"))}
+
+    it 'adds statement to deletes' do
+      expect { subject.delete(s) }
+        .to change { subject.deletes }.to contain_exactly(s)
+    end
+
+    it 'adds multiple statements to #deletes' do
+      statements = [].extend(RDF::Enumerable)
+      statements << [s, RDF::Statement(:node, RDF.type, RDF::URI('x'))]
+
+      expect { subject.delete(statements) }
+        .to change { subject.deletes }.to contain_exactly(*statements)
+    end
+  end
+
+  describe '#insert' do
+    let(:s) {RDF::Statement.new(RDF::URI("s"), RDF::URI("p"), RDF::URI("o"))}
+
+    it 'adds statement to inserts' do
+      expect { subject.insert(s) }
+        .to change { subject.inserts }.to contain_exactly(s)
+    end
+
+    it "adds multiple statements to #inserts" do
+      statements = [].extend(RDF::Enumerable)
+      statements << [s, RDF::Statement(:node, RDF.type, RDF::URI('x'))]
+
+      expect { subject.insert(statements) }
+        .to change { subject.inserts }.to contain_exactly(*statements)
+    end
+  end
+end

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -20,4 +20,21 @@ describe RDF::Repository do
       let(:repository) { RDF::Repository.new(with_validity: false) }
     end
   end
+
+  describe '#apply_changeset' do
+    let(:changeset) { double('changeset', deletes: dels, inserts: ins) }
+
+    let(:dels) { [] }
+    let(:ins)  { [] }
+    
+    it '' do
+      subject << existing_statement = RDF::Statement(:s, RDF.type, :o)
+      dels << existing_statement
+      ins << RDF::Statement(nil, nil, nil)
+
+      expect do
+        begin; subject.apply_changeset(changeset) rescue ArgumentError; end;
+      end.not_to change { subject.statements }
+    end
+  end
 end

--- a/spec/transaction_spec.rb
+++ b/spec/transaction_spec.rb
@@ -2,12 +2,13 @@ require File.join(File.dirname(__FILE__), 'spec_helper')
 require 'rdf/spec/transaction'
 
 describe RDF::Transaction do
+  let(:repository) { RDF::Repository.new }
+
   # @see lib/rdf/spec/transaction.rb in rdf-spec
   it_behaves_like "an RDF::Transaction", RDF::Transaction
 
   describe 'default implementation' do
-    subject          { described_class.new(repository, mutable: true) }
-    let(:repository) { RDF::Repository.new }
+    subject { described_class.new(repository, mutable: true) }
 
     describe '#buffered' do
       it 'is true if changeset has changes' do

--- a/spec/transaction_spec.rb
+++ b/spec/transaction_spec.rb
@@ -7,7 +7,7 @@ describe RDF::Transaction do
   # @see lib/rdf/spec/transaction.rb in rdf-spec
   it_behaves_like "an RDF::Transaction", RDF::Transaction
 
-  describe 'default implementation' do
+  describe 'base implementation' do
     subject { described_class.new(repository, mutable: true) }
 
     describe '#buffered' do
@@ -62,6 +62,13 @@ describe RDF::Transaction do
 
         expect { subject.delete(sts) }
           .to change { subject.changes.deletes }.to contain_exactly(*sts)
+      end
+    end
+
+    describe '#execute' do
+      it 'calls `changes#apply` with repository' do
+        expect(subject.changes).to receive(:apply).with(subject.repository)
+        subject.execute
       end
     end
   end

--- a/spec/transaction_spec.rb
+++ b/spec/transaction_spec.rb
@@ -4,4 +4,64 @@ require 'rdf/spec/transaction'
 describe RDF::Transaction do
   # @see lib/rdf/spec/transaction.rb in rdf-spec
   it_behaves_like "an RDF::Transaction", RDF::Transaction
+
+  describe 'default implementation' do
+    subject          { described_class.new(repository, mutable: true) }
+    let(:repository) { RDF::Repository.new }
+
+    describe '#buffered' do
+      it 'is true if changeset has changes' do
+        subject.insert([:s, :p, :o])
+        expect(subject).to(be_buffered)
+      end
+    end
+
+    describe "#insert" do
+      let(:st) { RDF::Statement(:s, RDF::URI('p'), 'o') }
+      
+      it 'adds to inserts' do
+        expect { subject.insert(st) }
+          .to change { subject.changes.inserts }.to contain_exactly(st)
+      end
+
+      it 'adds multiple to inserts' do
+        sts = [st] << RDF::Statement(:x, RDF::URI('y'), 'z')
+        
+        expect { subject.insert(*sts) }
+          .to change { subject.changes.inserts }.to contain_exactly(*sts)
+      end
+
+      it 'adds enumerable to inserts' do
+        sts = [st] << RDF::Statement(:x, RDF::URI('y'), 'z')
+        sts.extend(RDF::Enumerable)
+
+        expect { subject.insert(sts) }
+          .to change { subject.changes.inserts }.to contain_exactly(*sts)
+      end
+    end
+    
+    describe '#delete' do
+      let(:st) { RDF::Statement(:s, RDF::URI('p'), 'o') }
+
+      it 'adds to deletes' do
+        expect { subject.delete(st) }
+          .to change { subject.changes.deletes }.to contain_exactly(st)
+      end
+
+      it 'adds multiple to deletes' do
+        sts = [st] << RDF::Statement(:x, RDF::URI('y'), 'z')
+
+        expect { subject.delete(*sts) }
+          .to change { subject.changes.deletes }.to contain_exactly(*sts)
+      end
+
+      it 'adds enumerable to deletes' do
+        sts = [st] << RDF::Statement(:x, RDF::URI('y'), 'z')
+        sts.extend(RDF::Enumerable)
+
+        expect { subject.delete(sts) }
+          .to change { subject.changes.deletes }.to contain_exactly(*sts)
+      end
+    end
+  end
 end

--- a/spec/transaction_spec.rb
+++ b/spec/transaction_spec.rb
@@ -1,7 +1,7 @@
 require File.join(File.dirname(__FILE__), 'spec_helper')
 require 'rdf/spec/transaction'
 
-describe RDF::Transaction, skip: "pending fixes to immutability errors" do
+describe RDF::Transaction do
   # @see lib/rdf/spec/transaction.rb in rdf-spec
   it_behaves_like "an RDF::Transaction", RDF::Transaction
 end


### PR DESCRIPTION
For initial review. This gets changesets and transactions in a state that I think they are usable.

Before these changes, Transaction fails regularly with no method errors on nil  `#changes`. Instead of "talking to" a nil on `changes` we introduce `Changeset#empty?` and give each transaction a changeset on initialization.

This also implements `Transaction#execute`, pushing responsibility for transactionality down to the `Repository`, via `Changeset#apply`. `Enumerable#supports?(:transactions)` is introduced; and changesets can now be applied to any `Mutable`. `Transaction` is still a `Repository` only concept.

@bendiken, @gkellogg this could use an initial review. In the meanwhile, I'm picking up work on transactionality tests & support for the default repository.