### PR TITLE
Feature/pluggable executable

### DIFF
--- a/bin/rdf
+++ b/bin/rdf
@@ -5,7 +5,7 @@ require 'rdf/cli'
 
 options = RDF::CLI.options do
   self.on('-v', '--verbose', 'Enable verbose output. May be given more than once.') do
-    $VERBOSE = true
+    self.options[:logger].level = Logger::INFO
   end
 
   self.on('-V', '--version', 'Display the RDF.rb version and exit.') do

--- a/lib/rdf/cli.rb
+++ b/lib/rdf/cli.rb
@@ -48,7 +48,6 @@ module RDF
       #
       # @param [Symbol] symbol
       # @param [Array<String>] on
-      # @param [String] name
       # @param [String] description
       # @yield value which may be used within `OptionParser#on`
       # @yieldparam [Object] value The option value as parsed using `on` argument
@@ -212,7 +211,7 @@ module RDF
       end
 
       options.on("--output-format FORMAT", "Format of output file, defaults to NTriples") do |arg|
-        unless RDF::Writer.for(arg.downcase.to_sym)
+        unless writer = RDF::Writer.for(arg.downcase.to_sym)
           $stderr.puts "No writer found for #{arg.downcase.to_sym}. Available writers:\n  #{self.formats(writer: true).join("\n  ")}"
           exit(1)
         end

--- a/lib/rdf/cli.rb
+++ b/lib/rdf/cli.rb
@@ -43,20 +43,29 @@ module RDF
       # @return [String]
       attr_reader :description
 
+      # Argument datatype, which may be enumerated string values
+      # @return [Class, Array<String>]
+      attr_reader :datatype
+
+      # Allows multiple comma-spearated values.
+      # @return [Boolean]
+      attr_reader :multiple
+
       ##
       # Create a new option with optional callback.
       #
       # @param [Symbol] symbol
       # @param [Array<String>] on
       # @param [String] description
-      # @param [Class] datatype datatype of value
+      # @param [Class, Array<String>] datatype of value
+      # @param [Boolean] multiple can have multiple comma-separated values
       # @yield value which may be used within `OptionParser#on`
       # @yieldparam [Object] value The option value as parsed using `on` argument
       # @yieldreturn [Object] a possibly modified input value
-      def initialize(symbol: nil, on: nil, description: nil, datatype: String, &block)
+      def initialize(symbol: nil, on: nil, description: nil, datatype: String, multiple: false, &block)
         raise ArgumentError, "symbol is a required argument" unless symbol
         raise ArgumentError, "on is a required argument" unless on
-        @symbol, @on, @description, @datatype, @callback = symbol.to_sym, Array(on), description, datatype, block
+        @symbol, @on, @description, @datatype, @multiple, @callback = symbol.to_sym, Array(on), description, datatype, multiple, block
       end
 
       def call(arg)

--- a/lib/rdf/cli.rb
+++ b/lib/rdf/cli.rb
@@ -218,6 +218,14 @@ module RDF
         end
 
         # Add format-specific writer options
+        writer.options.each do |cli_opt|
+          next if opts.has_key?(cli_opt.symbol)
+          on_args = cli_opt.on || []
+          on_args << cli_opt.description if cli_opt.description
+          options.on(*on_args) do |arg|
+            opts[cli_opt.symbol] = cli_opt.call(arg)
+          end
+        end
         opts[:output_format] = arg.downcase.to_sym
       end
 

--- a/lib/rdf/cli.rb
+++ b/lib/rdf/cli.rb
@@ -53,7 +53,9 @@ module RDF
       # @yield value which may be used within `OptionParser#on`
       # @yieldparam [Object] value The option value as parsed using `on` argument
       # @yieldreturn [Object] a possibly modified input value
-      def initialize(symbol:, on:, description: nil, datatype: String, &block)
+      def initialize(symbol: nil, on: nil, description: nil, datatype: String, &block)
+        raise ArgumentError, "symbol is a required argument" unless symbol
+        raise ArgumentError, "on is a required argument" unless on
         @symbol, @on, @description, @datatype, @callback = symbol.to_sym, Array(on), description, datatype, block
       end
 

--- a/lib/rdf/cli.rb
+++ b/lib/rdf/cli.rb
@@ -49,11 +49,12 @@ module RDF
       # @param [Symbol] symbol
       # @param [Array<String>] on
       # @param [String] description
+      # @param [Class] datatype datatype of value
       # @yield value which may be used within `OptionParser#on`
       # @yieldparam [Object] value The option value as parsed using `on` argument
       # @yieldreturn [Object] a possibly modified input value
-      def initialize(symbol:, on:, description: nil, &block)
-        @symbol, @on, @description, @callback = symbol.to_sym, Array(on), description, block
+      def initialize(symbol:, on:, description: nil, datatype: String, &block)
+        @symbol, @on, @description, @datatype, @callback = symbol.to_sym, Array(on), description, datatype, block
       end
 
       def call(arg)

--- a/lib/rdf/format.rb
+++ b/lib/rdf/format.rb
@@ -359,6 +359,12 @@ module RDF
       end
     end
 
+    ##
+    # Hash of CLI commands appropriate for this format
+    # @return [Hash{Symbol => Lambda(Array, Hash)}]
+    def self.cli_commands
+      {}
+    end
 
     ##
     # Use a text sample to detect the format of an input file. Sub-classes implement

--- a/lib/rdf/reader.rb
+++ b/lib/rdf/reader.rb
@@ -109,6 +109,45 @@ module RDF
       end
     end
 
+    ##
+    # Options suitable for automatic Reader provisioning.
+    # @return [Array<RDF::CLI::Option>]
+    def self.options
+      [
+        RDF::CLI::Option.new(
+          symbol: :canonicalize,
+          on: ["--canonicalize"],
+          description: "Canonicalize input/output.") {true},
+        RDF::CLI::Option.new(
+          symbol: :encoding,
+          on: ["--encoding ENCODING"],
+          description: "The encoding of the input stream.") {|arg| Encoding.find arg},
+        RDF::CLI::Option.new(
+          symbol: :intern,
+          on: ["--intern"],
+          description: "Intern all parsed URIs.") {true},
+        RDF::CLI::Option.new(
+          symbol: :prefixes,
+          on: ["--prefixes PREFIX,PREFIX"],
+          description: "A space-separated list of prefix:uri pairs.") do |arg|
+            arg.split(' ').inject({}) do |memo, pfxuri|
+              pfx,uri = pfxuri.split(':', 2)
+              memo.merge(pfx.to_sym => RDF::URI(uri))
+            end
+        end,
+        RDF::CLI::Option.new(
+          symbol: :base_uri,
+          on: ["--uri URI"],
+          description: "Base URI of input file, defaults to the filename."),
+        RDF::CLI::Option.new(
+          symbol: :validate,
+          on: ["--validate"],
+          description: "Validate input file.") {true},
+      ]
+    end
+
+    # Returns a hash of options appropriate for use with this reader
+    
     class << self
       alias_method :format_class, :format
     end

--- a/lib/rdf/reader.rb
+++ b/lib/rdf/reader.rb
@@ -116,18 +116,22 @@ module RDF
       [
         RDF::CLI::Option.new(
           symbol: :canonicalize,
+          datatype: TrueClass,
           on: ["--canonicalize"],
           description: "Canonicalize input/output.") {true},
         RDF::CLI::Option.new(
           symbol: :encoding,
+          datatype: Encoding,
           on: ["--encoding ENCODING"],
           description: "The encoding of the input stream.") {|arg| Encoding.find arg},
         RDF::CLI::Option.new(
           symbol: :intern,
+          datatype: TrueClass,
           on: ["--intern"],
           description: "Intern all parsed URIs.") {true},
         RDF::CLI::Option.new(
           symbol: :prefixes,
+          datatype: Hash,
           on: ["--prefixes PREFIX,PREFIX"],
           description: "A space-separated list of prefix:uri pairs.") do |arg|
             arg.split(' ').inject({}) do |memo, pfxuri|
@@ -137,10 +141,12 @@ module RDF
         end,
         RDF::CLI::Option.new(
           symbol: :base_uri,
+          datatype: RDF::URI,
           on: ["--uri URI"],
-          description: "Base URI of input file, defaults to the filename."),
+          description: "Base URI of input file, defaults to the filename.") {|arg| RDF::URI(arg)},
         RDF::CLI::Option.new(
           symbol: :validate,
+          datatype: TrueClass,
           on: ["--validate"],
           description: "Validate input file.") {true},
       ]

--- a/lib/rdf/reader.rb
+++ b/lib/rdf/reader.rb
@@ -132,9 +132,10 @@ module RDF
         RDF::CLI::Option.new(
           symbol: :prefixes,
           datatype: Hash,
+          multiple: true,
           on: ["--prefixes PREFIX,PREFIX"],
-          description: "A space-separated list of prefix:uri pairs.") do |arg|
-            arg.split(' ').inject({}) do |memo, pfxuri|
+          description: "A comma-separated list of prefix:uri pairs.") do |arg|
+            arg.split(',').inject({}) do |memo, pfxuri|
               pfx,uri = pfxuri.split(':', 2)
               memo.merge(pfx.to_sym => RDF::URI(uri))
             end

--- a/lib/rdf/reader.rb
+++ b/lib/rdf/reader.rb
@@ -139,6 +139,7 @@ module RDF
         format_options[:content_type] ||= file.content_type if file.respond_to?(:content_type)
         format_options[:file_name] ||= filename
         options[:encoding] ||= file.encoding if file.respond_to?(:encoding)
+        options[:filename] ||= filename
         reader = self.for(format || format_options) do
           # Return a sample from the input file
           sample = file.read(1000)

--- a/lib/rdf/util/file.rb
+++ b/lib/rdf/util/file.rb
@@ -327,7 +327,8 @@ module RDF; module Util
           url_no_frag_or_query = RDF::URI(filename_or_url)
           url_no_frag_or_query.query = nil
           url_no_frag_or_query.fragment = nil
-          Kernel.open(url_no_frag_or_query, "r:utf-8", options) do |file|
+          options[:encoding] ||= Encoding::UTF_8
+          Kernel.open(url_no_frag_or_query, "r", options) do |file|
             document_options = {
               base_uri:     filename_or_url.to_s,
               charset:      file.external_encoding.to_s,

--- a/lib/rdf/writer.rb
+++ b/lib/rdf/writer.rb
@@ -112,7 +112,7 @@ module RDF
     end
 
     ##
-    # Options suitable for automatic Reader provisioning.
+    # Options suitable for automatic Writer provisioning.
     # @return [Array<RDF::CLI::Option>]
     def self.options
       [
@@ -124,14 +124,15 @@ module RDF
         RDF::CLI::Option.new(
           symbol: :encoding,
           datatype: Encoding,
-          on: ["--encoding", :REQUIRED],
+          on: ["--encoding ENCODING"],
           description: "The encoding of the input stream.") {|arg| Encoding.find arg},
         RDF::CLI::Option.new(
           symbol: :prefixes,
           datatype: Hash,
-          on: ["--prefixes", :REQUIRED],
-          description: "A space-separated list of prefix:uri pairs.") do |arg|
-            arg.split(' ').inject({}) do |memo, pfxuri|
+          multiple: true,
+          on: ["--prefixes PREFIX,PREFIX"],
+          description: "A comma-separated list of prefix:uri pairs.") do |arg|
+            arg.split(',').inject({}) do |memo, pfxuri|
               pfx,uri = pfxuri.split(':', 2)
               memo.merge(pfx.to_sym => RDF::URI(uri))
             end

--- a/lib/rdf/writer.rb
+++ b/lib/rdf/writer.rb
@@ -111,6 +111,35 @@ module RDF
       end
     end
 
+    ##
+    # Options suitable for automatic Reader provisioning.
+    # @return [Array<RDF::CLI::Option>]
+    def self.options
+      [
+        RDF::CLI::Option.new(
+          symbol: :canonicalize,
+          on: ["--canonicalize"],
+          description: "Canonicalize input/output.") {true},
+        RDF::CLI::Option.new(
+          symbol: :encoding,
+          on: ["--encoding", :REQUIRED],
+          description: "The encoding of the input stream.") {|arg| Encoding.find arg},
+        RDF::CLI::Option.new(
+          symbol: :prefixes,
+          on: ["--prefixes", :REQUIRED],
+          description: "A space-separated list of prefix:uri pairs.") do |arg|
+            arg.split(' ').inject({}) do |memo, pfxuri|
+              pfx,uri = pfxuri.split(':', 2)
+              memo.merge(pfx.to_sym => RDF::URI(uri))
+            end
+        end,
+        RDF::CLI::Option.new(
+          symbol: :unique_bnodes,
+          on: ["--unique-bnodes"],
+          description: "Use unique Node identifiers.") {true},
+      ]
+    end
+
     class << self
       alias_method :format_class, :format
     end

--- a/lib/rdf/writer.rb
+++ b/lib/rdf/writer.rb
@@ -118,14 +118,17 @@ module RDF
       [
         RDF::CLI::Option.new(
           symbol: :canonicalize,
+          datatype: TrueClass,
           on: ["--canonicalize"],
           description: "Canonicalize input/output.") {true},
         RDF::CLI::Option.new(
           symbol: :encoding,
+          datatype: Encoding,
           on: ["--encoding", :REQUIRED],
           description: "The encoding of the input stream.") {|arg| Encoding.find arg},
         RDF::CLI::Option.new(
           symbol: :prefixes,
+          datatype: Hash,
           on: ["--prefixes", :REQUIRED],
           description: "A space-separated list of prefix:uri pairs.") do |arg|
             arg.split(' ').inject({}) do |memo, pfxuri|
@@ -135,6 +138,7 @@ module RDF
         end,
         RDF::CLI::Option.new(
           symbol: :unique_bnodes,
+          datatype: TrueClass,
           on: ["--unique-bnodes"],
           description: "Use unique Node identifiers.") {true},
       ]

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -59,4 +59,13 @@ describe RDF::CLI do
       end
     end
   end
+
+  describe "#validate" do
+    TEST_FILES.each do |fmt, file|
+      it "validates #{fmt}" do
+        g = RDF::Repository.load(file)
+        expect {RDF::CLI.exec_command("validate", [file])}.to write(/Validated #{g.count} statements/)
+      end
+    end
+  end
 end


### PR DESCRIPTION
I think this adequately allows for a certain amount of pluggable behavior, at least in terms of allowing readers and writers to specify options specific to their formats. It also validates formats used, and provides feedback on available formats.

The CLI::Option class is useful both for provisioning additional options to show up in the CLI (although option ordering isn't what you'd like) and for generating an HTML form for these options in the distiller and/or linter eventually.

`RDF::Reader.options` and `RDF::Writer.options` return an array of `RDF::CLI::Option` that help do this provisioning.

I've made changes to the develop branch of several readers and writers to take advantage of this; more to come.

Probably best to squash commits when merging.