### PR TITLE
Remove RDF::Inferable module as being not useful. The same functional…

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,6 @@ from BNode identity (i.e., they each entail the other)
   * {RDF::Countable}
   * {RDF::Enumerable}
   * {RDF::Indexable}
-  * {RDF::Inferable}
   * {RDF::Queryable}
   * {RDF::Mutable}
   * {RDF::Durable}

--- a/lib/rdf.rb
+++ b/lib/rdf.rb
@@ -11,7 +11,6 @@ module RDF
   autoload :Durable,     'rdf/mixin/durable'
   autoload :Enumerable,  'rdf/mixin/enumerable'
   autoload :Indexable,   'rdf/mixin/indexable'
-  autoload :Inferable,   'rdf/mixin/inferable'
   autoload :Mutable,     'rdf/mixin/mutable'
   autoload :Queryable,   'rdf/mixin/queryable'
   autoload :Readable,    'rdf/mixin/readable'

--- a/lib/rdf/mixin/inferable.rb
+++ b/lib/rdf/mixin/inferable.rb
@@ -1,5 +1,0 @@
-module RDF
-  ##
-  # @see http://github.com/bendiken/rdfs
-  module Inferable; end
-end

--- a/spec/mixin_inferable_spec.rb
+++ b/spec/mixin_inferable_spec.rb
@@ -1,7 +1,0 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
-require 'rdf/spec/inferable'
-
-describe RDF::Inferable do
-  # @see lib/rdf/spec/enumerable.rb in rdf-spec
-  it_behaves_like 'an RDF::Inferable'
-end


### PR DESCRIPTION
…ity is available using `#supports :inference`. Fixes #252.