### PR TITLE
Use `benchmark/ips` for query benchmarks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,8 @@ group :develop do
   gem 'sparql-client',  git: "git://github.com/ruby-rdf/sparql-client.git", branch: "develop"
   gem 'sxp',            git: "git://github.com/gkellogg/sxp-ruby.git"
   gem 'rest-client-components'
+
+  gem 'benchmark-ips'
 end
 
 group :debug do

--- a/examples/query_bench.rb
+++ b/examples/query_bench.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-require 'benchmark'
+require 'benchmark/ips'
 require 'rdf'
 require 'rdf/vocab'
 require 'rdf/ntriples'
@@ -8,10 +8,7 @@ graph = RDF::Graph.load("etc/doap.nt")
 
 puts graph.query(predicate: RDF::Vocab::FOAF.name).is_a?(RDF::Queryable)
 
-Benchmark.bmbm do |bench|
-  bench.report("query_pattern") do
-    100_000.times do
-      graph.query(predicate: RDF::Vocab::FOAF.name) {}
-    end
-  end
+Benchmark.ips do |x|
+  x.config(:time => 10, :warmup => 5)
+  x.report('query_pattern') { graph.query(predicate: RDF::Vocab::FOAF.name) {} }
 end


### PR DESCRIPTION
`Benchmark.ips` takes an iterations/second approach to benchmarking,
instead of running the code snippet a specific number of times. This
makes for nicer comparisons. It also reports a standard deviation.

The new output for the query benchmark will look like:

```
Calculating -------------------------------------
       query_pattern   667.000  i/100ms
-------------------------------------------------
       query_pattern      6.762k (± 1.8%) i/s -     68.034k
```

@gkellogg I'm finding this nicer for comparing the two in-memory repositories, right now; if this doesn't seem preferable to you, go ahead and close it.