### PR TITLE
Make `#durable?` false for default Repository

### DIFF
--- a/lib/rdf/model/dataset.rb
+++ b/lib/rdf/model/dataset.rb
@@ -10,6 +10,7 @@ module RDF
   class Dataset
     include RDF::Countable
     include RDF::Enumerable
+    include RDF::Durable
     include RDF::Queryable
 
     ISOLATION_LEVELS = [ :read_uncommitted, 

--- a/lib/rdf/repository.rb
+++ b/lib/rdf/repository.rb
@@ -261,6 +261,13 @@ module RDF
       
       ##
       # @private
+      # @see RDF::Durable#durable?
+      def durable?
+        false
+      end
+      
+      ##
+      # @private
       # @see RDF::Enumerable#has_graph?      
       def has_graph?(graph)
         @data.has_key?(graph)

--- a/lib/rdf/repository.rb
+++ b/lib/rdf/repository.rb
@@ -41,7 +41,6 @@ module RDF
   #   repository.clear!
   #
   class Repository < Dataset
-    include RDF::Durable
     include RDF::Mutable
 
     DEFAULT_TX_CLASS = RDF::Transaction

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -8,6 +8,8 @@ describe RDF::Repository do
     let(:repository) { RDF::Repository.new }
   end
 
+  it { is_expected.not_to be_durable }
+
   it "maintains arbitrary options" do
     repository = RDF::Repository.new(foo: :bar)
     expect(repository.options).to have_key(:foo)


### PR DESCRIPTION
It looks like this method was dropped in the initial Hamster commit: https://github.com/ruby-rdf/rdf/commit/8d18107d9094aba328a26cb6019fa562fce15ab6#diff-d8b3d406cfa5a91c317a8513a0c9fa0dL251

The in-memory repository should be non-durable.