### PR TITLE
Fix NTriples serialization with RDF::Raptor

### DIFF
--- a/lib/rdf/ntriples.rb
+++ b/lib/rdf/ntriples.rb
@@ -62,7 +62,7 @@ module RDF
     # @see    RDF::NTriples::Writer.serialize
     # @since  0.1.5
     def self.serialize(value)
-      Writer.serialize(value)
+      Writer.for(:ntriples).serialize(value)
     end
 
     ##


### PR DESCRIPTION
When using `RDF::Raptor::NTriples::Writer`, it expects to replace `RDF::NTriples::Writer` as the writer for the `:ntriples` format. In some cases, this means that `RDF::NTriples::Format` never gets loaded, causing `RDF::NTriples::Writer.format` to return `nil`. This breaks the [RDF::Writer#encoding](https://github.com/ruby-rdf/rdf/blob/51107f023a58dff6a1766e4512454a19e3c441a7/lib/rdf/writer.rb#L353) method.

This fixes the issue by ensuring that the correct writer is selected when serializing a value. This is intended to work in conjunction with https://github.com/ruby-rdf/rdf-raptor/pull/24.