### PR TITLE
Only use tx on #delete_insert for :atomic_write

### DIFF
--- a/lib/rdf/mixin/mutable.rb
+++ b/lib/rdf/mixin/mutable.rb
@@ -201,7 +201,7 @@ module RDF
     ##
     # Applies the given changeset
     #
-    # If `#supports?(:transactions)` is `true`, this must apply the changeset
+    # If `#supports?(:atomic_write)` is `true`, this must apply the changeset
     # atomically. Otherwise, it should offer an efficient implementation of a 
     # combined delete/insert of the changeset.
     #

--- a/lib/rdf/repository.rb
+++ b/lib/rdf/repository.rb
@@ -150,6 +150,8 @@ module RDF
     #
     # @see RDF::Mutable#delete_insert
     def delete_insert(deletes, inserts)
+      return super unless supports?(:atomic_write)
+
       transaction(mutable: true) do
         deletes.respond_to?(:each_statement) ? delete(deletes) : delete(*deletes)
         inserts.respond_to?(:each_statement) ? insert(inserts) : insert(*inserts)
@@ -291,7 +293,7 @@ module RDF
         enum_statement
       end
       alias_method :each, :each_statement
-      
+
       ##
       # @see Mutable#apply_changeset
       def apply_changeset(changeset)


### PR DESCRIPTION
Repositories that don't support :atomic_write shouldn't try to use a transaction for #delete_insert.

Repositories answering `true` to `:atomic_write` promise to deliver an atomic `#apply_changeset`.