### PR TITLE
Feature/tx query graph

### DIFF
--- a/lib/rdf/transaction.rb
+++ b/lib/rdf/transaction.rb
@@ -74,7 +74,7 @@ module RDF
     ##
     # @see RDF::Enumerable#each
     def each(*args, &block)
-      @snapshot.each(*args, &block)
+      read_target.each(*args, &block)
     end
 
     ##
@@ -204,6 +204,12 @@ module RDF
     end
 
     ##
+    # @see RDF::Enumerable#has_statement?
+    def has_statement?(statement)
+      read_target.has_statement?(statement)
+    end
+
+    ##
     # Returns a developer-friendly representation of this transaction.
     #
     # @return [String]
@@ -271,11 +277,11 @@ module RDF
     end
 
     def query_pattern(*args, &block)
-      @snapshot.send(:query_pattern, *args, &block)
+      read_target.send(:query_pattern, *args, &block)
     end
 
     def query_execute(*args, &block)
-      @snapshot.send(:query_execute, *args, &block)
+      read_target.send(:query_execute, *args, &block)
     end
   
     undef_method :load, :update, :clear
@@ -289,11 +295,17 @@ module RDF
     # @param statement [RDF::Statement]
     # @return [RDF::Statement]
     def process_statement(statement)
-      if graph_name && statement.graph_name.nil?
+      if graph_name
         statement = statement.dup
         statement.graph_name = graph_name
       end
       statement
+    end
+    
+    def read_target
+      return @snapshot if graph_name.nil?
+      return @snapshot.project_graph(nil) if graph_name == false
+      @snapshot.project_graph(graph_name)
     end
 
     public

--- a/spec/model_graph_spec.rb
+++ b/spec/model_graph_spec.rb
@@ -200,6 +200,15 @@ describe RDF::Graph do
   context "when querying statements" do
     require 'rdf/spec/queryable'
     it_behaves_like 'an RDF::Queryable'
+
+    context 'with graph_name' do
+      require 'rdf/spec/queryable'
+      it_behaves_like 'an RDF::Queryable' do
+        let(:queryable) do
+          RDF::Graph.new(graph_name: RDF::URI('g'), data: RDF::Repository.new)
+        end
+      end
+    end
   end
 
   context "Examples" do


### PR DESCRIPTION
This would close #269 and #278. The failing specs in CI call out a pre-existing issue with RDF::Graph's Queryable support that needs to be resolved before merge.

This changes the Transaction semantics to behave like Graph. Queryable is somewhat opinionated that inserting triples to a queryable should result in those triples being accessible through query. In light of this, the answer to #278 seems to be that graph scope must be symmetrical for read and write operations. That interpretation is implemented in the PR.

The remaining blocker is: Queryable's shared examples require a query pattern's graph name to be retained when querying, but Graph overwrites it.

My inclination is to change the specs (skip when `#graph_name` is defined), keeping the existing behavior. Thoughts, @gkellogg?
