### PR TITLE
Allow for 1.E-8 to be turned into an object

### DIFF
--- a/lib/rdf/model/literal/double.rb
+++ b/lib/rdf/model/literal/double.rb
@@ -27,7 +27,7 @@ module RDF; class Literal
           when 'INF'  then 1/0.0
           when '-INF' then -1/0.0
           when 'NaN'  then 0/0.0
-          else Float(value) rescue nil
+          else Float(value.sub(/\.[eE]/, '.0E')) rescue nil
         end
         when value.is_a?(::Float)     then value
         when value.respond_to?(:to_f) then value.to_f
@@ -43,6 +43,7 @@ module RDF; class Literal
     def canonicalize!
       # Can't use simple %f transformation due to special requirements from
       # N3 tests in representation
+      require 'byebug'; byebug if @object.nil?
       @string = case
         when @object.nan?      then 'NaN'
         when @object.infinite? then @object.to_s[0...-'inity'.length].upcase

--- a/spec/model_literal_spec.rb
+++ b/spec/model_literal_spec.rb
@@ -422,6 +422,7 @@ describe RDF::Literal do
       %w(1.0e+1    1.0E1),
       %w(1.0e-10   1.0E-10),
       %w(123.456e4 1.23456E6),
+      %w(1.E-8     1.0E-8),
       %w(+INF      INF),
       %w(INF       INF),
       %w(-INF      -INF),


### PR DESCRIPTION
Ruby Float() requires a digit after the decimal place.