### PR TITLE
Freeze Literal, Node and URI values on instantiation.

### DIFF
--- a/lib/rdf/model/literal.rb
+++ b/lib/rdf/model/literal.rb
@@ -162,13 +162,13 @@ module RDF
     # @see http://www.w3.org/TR/rdf11-concepts/#section-Graph-Literal
     # @see http://www.w3.org/TR/rdf11-concepts/#section-Datatypes
     def initialize(value, options = {})
-      @object   = value
+      @object   = value.freeze
       @string   = options[:lexical] if options[:lexical]
       @string   = value if !defined?(@string) && value.is_a?(String)
-      @string   = @string.encode(Encoding::UTF_8) if @string
+      @string   = @string.encode(Encoding::UTF_8).freeze if @string
       @object   = @string if @string && @object.is_a?(String)
       @language = options[:language].to_s.downcase.to_sym if options[:language]
-      @datatype = RDF::URI(options[:datatype]) if options[:datatype]
+      @datatype = RDF::URI(options[:datatype]).freeze if options[:datatype]
       @datatype ||= self.class.const_get(:DATATYPE) if self.class.const_defined?(:DATATYPE)
       @datatype ||= @language ? RDF.langString : RDF::XSD.string
       raise ArgumentError, "datatype of rdf:langString requires a language" if !@language && @datatype == RDF::langString
@@ -425,7 +425,8 @@ module RDF
              gsub("\n", '\\n').
              gsub("\r", '\\r').
              gsub("\f", '\\f').
-             gsub('"', '\\"')
+             gsub('"', '\\"').
+             freeze
     end
 
     ##
@@ -433,7 +434,7 @@ module RDF
     #
     # @return [String]
     def to_s
-      @object.to_s
+      @object.to_s.freeze
     end
 
     ##
@@ -442,7 +443,7 @@ module RDF
     # @return [String]
     # @since 1.1.6
     def humanize(lang = :en)
-      to_s
+      to_s.freeze
     end
 
     ##

--- a/lib/rdf/model/node.rb
+++ b/lib/rdf/model/node.rb
@@ -55,7 +55,7 @@ module RDF
     # @return [RDF::Node]
     # @since  0.2.0
     def self.intern(id)
-      (cache[id = id.to_s] ||= self.new(id)).freeze
+      (cache[(id = id.to_s).to_sym] ||= self.new(id)).freeze
     end
 
     ##
@@ -82,7 +82,7 @@ module RDF
     # @param  [#to_s] id
     def initialize(id = nil)
       id = nil if id.to_s.empty?
-      @id = (id || "g#{__id__.to_i.abs}").to_s
+      @id = (id || "g#{__id__.to_i.abs}").to_s.freeze
     end
 
     ##

--- a/lib/rdf/model/term.rb
+++ b/lib/rdf/model/term.rb
@@ -57,14 +57,6 @@ module RDF
     end
 
     ##
-    # Returns a base representation of `self`.
-    #
-    # @return [RDF::Value]
-    def to_base
-      self
-    end
-
-    ##
     # Returns `true` if `self` is a {RDF::Term}.
     #
     # @return [Boolean]
@@ -85,7 +77,7 @@ module RDF
     #
     # @return [Sring]
     def to_base
-      RDF::NTriples.serialize(self)
+      RDF::NTriples.serialize(self).freeze
     end
 
     ##

--- a/lib/rdf/model/uri.rb
+++ b/lib/rdf/model/uri.rb
@@ -143,7 +143,7 @@ module RDF
     # @return [RDF::URI] an immutable, frozen URI object
     def self.intern(*args)
       str = args.first
-      (cache[str = str.to_s] ||= self.new(*args)).freeze
+      (cache[(str = str.to_s).to_sym] ||= self.new(*args)).freeze
     end
 
     ##
@@ -229,6 +229,7 @@ module RDF
         if @value.encoding != Encoding::UTF_8
           @value = @value.dup if @value.frozen?
           @value.force_encoding(Encoding::UTF_8)
+          @value.freeze
         end
       else
         %w(
@@ -815,7 +816,7 @@ module RDF
         path,
         ("?#{query}" if query),
         ("##{fragment}" if fragment)
-      ].compact.join("")
+      ].compact.join("").freeze
     end
 
     ##

--- a/spec/model_node_spec.rb
+++ b/spec/model_node_spec.rb
@@ -11,7 +11,7 @@ describe RDF::Node do
     before(:each) {RDF::URI.instance_variable_set(:@cache, nil)}
     it "caches Node instance" do
       RDF::Node.intern("a")
-      expect(RDF::Node.instance_variable_get(:@cache)["a"]).to eq RDF::Node.intern("a")
+      expect(RDF::Node.instance_variable_get(:@cache)[:a]).to eq RDF::Node.intern("a")
     end
 
     it "freezes instance" do

--- a/spec/model_uri_spec.rb
+++ b/spec/model_uri_spec.rb
@@ -10,7 +10,7 @@ describe RDF::URI do
     before(:each) {RDF::URI.instance_variable_set(:@cache, nil)}
     it "caches URI instance" do
       RDF::URI.intern("a")
-      expect(RDF::URI.instance_variable_get(:@cache)["a"]).to eq RDF::URI("a")
+      expect(RDF::URI.instance_variable_get(:@cache)[:a]).to eq RDF::URI("a")
     end
 
     it "freezes instance" do


### PR DESCRIPTION
Use symbol, rather than string, to index intern cache.