### PR TITLE
Remove deprecated methods from RDF::Transaction

### DIFF
--- a/lib/rdf/transaction.rb
+++ b/lib/rdf/transaction.rb
@@ -114,26 +114,6 @@ module RDF
     attr_reader :changes
 
     ##
-    # RDF statements to delete when executed.
-    #
-    # @deprecated
-    # @return [RDF::Enumerable]
-    def deletes
-      warn "[DEPRECATION] Transaction#deletes now uses keyword arguments. Called from #{Gem.location_of_caller.join(':')}"
-      self.changes.deletes
-    end
-
-    ##
-    # RDF statements to insert when executed.
-    #
-    # @deprecated
-    # @return [RDF::Enumerable]
-    def inserts
-      warn "[DEPRECATION] Transaction#inserts now uses keyword arguments. Called from #{Gem.location_of_caller.join(':')}"
-      self.changes.inserts
-    end
-
-    ##
     # Any additional options for this transaction.
     #
     # @return [Hash{Symbol => Object}]


### PR DESCRIPTION
Pretty generous of us to leave these in for 2.0; let's remove them for the next minor release.

This PR can probably wait until a 2.1 is required by another feature.