### PR TITLE
Work around odd Rubinius problem involing variable arguments and super

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ rvm:
   - rbx-2
 cache: bundler
 sudo: false
-matrix:
-  allow_failures:
-    - rvm: rbx-2
 addons:
   code_climate:
     repo_token: 5806cc8a21c03f4e2f9d3b9d98d5d9fe084b66243b1dbb27b467dbc795acdcac

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ group :debug do
   gem "wirble"
   gem "redcarpet", platforms: :ruby
   gem "byebug", platforms: :mri
+  gem 'rubinius-debugger', platform: :rbx
   gem 'guard-rspec'
 end
 

--- a/lib/rdf/vocabulary.rb
+++ b/lib/rdf/vocabulary.rb
@@ -527,7 +527,13 @@ module RDF
       #     Attributes of this vocabulary term, used for finding `label` and `comment` and to serialize the term back to RDF
       def initialize(*args, **options)
         @attributes = options.fetch(:attributes)
-        super
+        if RUBY_ENGINE == "rbx"
+          # FIXME: Somehow, this gets messed up in Rubinius
+          args << options
+          super(*args)
+        else
+          super
+        end
       end
 
       ##

--- a/spec/vocabulary_spec.rb
+++ b/spec/vocabulary_spec.rb
@@ -122,7 +122,6 @@ describe RDF::Vocabulary do
       expect(RDF).to be_a_vocabulary("http://www.w3.org/1999/02/22-rdf-syntax-ns#")
       expect(RDF).to have_properties("http://www.w3.org/1999/02/22-rdf-syntax-ns#", %w(first object predicate rest subject type value))
       expect(RDF).to have_terms("http://www.w3.org/1999/02/22-rdf-syntax-ns#", %w(datatype Description parseType ID nodeID li))
-      expect(RDF).to have_terms("http://www.w3.org/1999/02/22-rdf-syntax-ns#", %w(datatype Description parseType ID nodeID li))
       %w(first object predicate rest subject type value).each do |p|
         expect(RDF.send(p)).to eq RDF::URI("http://www.w3.org/1999/02/22-rdf-syntax-ns##{p}")
       end


### PR DESCRIPTION
This works around an apparent Rubinius bug having to do with methods taking variable arguments, and `**options` then using `super`. With this workaround, Rubinius no finally passes all tests.

The offending code was in `RDF::Vocabulary::Term#initialize`.