### PR TITLE
Use Rubinius 3.x in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rvm:
   - 2.2.4
   - 2.3.1
   - jruby-9.0.4.0
-  - rbx-2
+  - rbx-3
 cache: bundler
 sudo: false
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rvm:
   - 2.2.4
   - 2.3.1
   - jruby-9.0.4.0
-  - rbx-3
+  - rbx
 cache: bundler
 sudo: false
 addons:


### PR DESCRIPTION
Rubinius 2.x is no longer being developed. This change will use the current Rubinius versions (3.x) as they are released.