### PR TITLE
do not fail with Encoding::CompatibilityError when normalizing unicode IRIs

### DIFF
--- a/lib/rdf/model/uri.rb
+++ b/lib/rdf/model/uri.rb
@@ -377,7 +377,7 @@ module RDF
       @object = {
         scheme: normalized_scheme,
         authority: normalized_authority,
-        path: normalized_path.sub(/\/+/, '/'),
+        path: normalized_path.squeeze('/'),
         query: normalized_query,
         fragment: normalized_fragment
       }
@@ -887,7 +887,7 @@ module RDF
     # Return normalized version of scheme, if any
     # @return [String]
     def normalized_scheme
-      scheme.strip.downcase if scheme
+      normalize_segment(scheme.strip, SCHEME, true) if scheme
     end
 
     ##
@@ -965,7 +965,7 @@ module RDF
     # @return [String]
     def normalized_host
       # Remove trailing '.' characters
-      normalize_segment(host, IHOST, true).sub(/\.*$/, '') if host
+      normalize_segment(host, IHOST, true).chomp('.') if host
     end
 
     ##
@@ -1059,7 +1059,7 @@ module RDF
 
       res = self.class.normalize_path(norm_segs.join("/"))
       # Special rules for specific protocols having empty paths
-      res.empty? ? (%w(http https ftp tftp).include?(normalized_scheme) ? '/' : "") : res
+      normalize_segment(res.empty? ? (%w(http https ftp tftp).include?(normalized_scheme) ? '/' : "") : res, IHIER_PART)
     end
 
     ##
@@ -1134,9 +1134,9 @@ module RDF
     # @return [String]
     def normalized_authority
       if authority
-        (userinfo ? "#{normalized_userinfo}@" : "") +
+        (userinfo ? normalized_userinfo.to_s + "@" : "") +
         normalized_host.to_s +
-        (normalized_port ? ":#{normalized_port}" : "")
+        (normalized_port ? ":" + normalized_port.to_s : "")
       end
     end
 

--- a/spec/model_uri_spec.rb
+++ b/spec/model_uri_spec.rb
@@ -477,6 +477,12 @@ describe RDF::URI do
       expect(u1.canonicalize!.to_s).to eq u2.to_s
       expect(u1).to eq u2
     end
+    it "#canonicalize does not fail with Encoding::CompatibilityError on weird IRIs" do
+      u1 = RDF::URI "htЫtp://user:passoЫd@exaЫmple.com:8080/path ПУТЬ?queЫry=valЫue#fragmeЫnt"
+      u2 = RDF::URI "ht%D0%ABtp://user:passoЫd@exaЫmple.com:8080/path%20ПУТЬ?queЫry=valЫue#fragmeЫnt"
+      expect(u1.canonicalize.to_s.dup.force_encoding(u2.to_s.encoding)).to eq u2.to_s
+      expect(u1).to eq u1
+    end
   end
 
   describe "#/" do


### PR DESCRIPTION
Problem that led to this PR:

```
2.1.0 :003 > u = RDF::URI.new 'http://example.com/путь?q=вопрос'
 => #<RDF::URI:0x1463c54 URI:http://example.com/путь?q=вопрос>
2.1.0 :005 > u.canonicalize
Encoding::CompatibilityError: incompatible character encodings: UTF-8 and US-ASCII
        from /home/ujif/pro/rdf/lib/rdf/model/uri.rb:819:in `join'
```