### PR TITLE
Add ruby 2.4.0-preview1 to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,12 @@ rvm:
   - 2.1
   - 2.2.4
   - 2.3.1
+  - 2.4.0-preview1
   - jruby-9.0.4.0
   - rbx
+matrix:
+  allow_failures:
+    - rvm: 2.4.0-preview1
 cache: bundler
 sudo: false
 addons:


### PR DESCRIPTION
Ruby 2.4.0-preview1 was released a few days ago. This is an early
release due to significant changes:
https://www.ruby-lang.org/en/news/2016/06/20/ruby-2-4-0-preview1-released/.

I've allowed failures for the branch, since support won't be important
until the early winter. Still, we're passing now, and I can't see any
reason not to maintain that as we review future PRs.