### PR TITLE
Fix RDF::List#== comparisons to RDF::Values 

### DIFF
--- a/lib/rdf/model/list.rb
+++ b/lib/rdf/model/list.rb
@@ -140,6 +140,13 @@ module RDF
     attr_reader :graph
 
     ##
+    # @see RDF::Value#==
+    def ==(other)
+      return false if other.is_a?(RDF::Value) && !other.list?
+      super
+    end
+
+    ##
     # Returns the set intersection of this list and `other`.
     #
     # The resulting list contains the elements common to both lists, with no
@@ -272,7 +279,7 @@ module RDF
     #     a[3, 0] = "B"               #=> [1, 2, "A", "B"]
     #
     # @overload []=(index, term)
-    #   Replaces the element at `index` with `term`. 
+    #   Replaces the element at `index` with `term`.
     #   @param [Integer] index
     #   @param [RDF::Term] term
     #     A non-RDF::Term is coerced to a Literal.

--- a/lib/rdf/model/statement.rb
+++ b/lib/rdf/model/statement.rb
@@ -135,7 +135,7 @@ module RDF
     #
     # @return [Boolean]
     def variable?
-      !(has_subject?    && subject.resource? && 
+      !(has_subject?    && subject.resource? &&
         has_predicate?  && predicate.resource? &&
         has_object?     && (object.resource? || object.literal?) &&
         (has_graph?     ? graph_name.resource? : true ))
@@ -150,7 +150,7 @@ module RDF
     ##
     # @return [Boolean]
     def valid?
-      has_subject?    && subject.resource? && subject.valid? && 
+      has_subject?    && subject.resource? && subject.valid? &&
       has_predicate?  && predicate.uri? && predicate.valid? &&
       has_object?     && object.term? && object.valid? &&
       (has_graph?      ? graph_name.resource? && graph_name.valid? : true )
@@ -252,25 +252,26 @@ module RDF
     # @see RDF::Literal#==
     # @see RDF::Query::Variable#==
     def ==(other)
-      to_a == Array(other)
+      to_a == Array(other) &&
+        !(other.is_a?(RDF::Value) && other.list?)
     end
 
     ##
     # Checks statement equality with patterns.
-    # 
+    #
     # Uses `#eql?` to compare each of `#subject`, `#predicate`, `#object`, and
-    # `#graph_name` to those of `other`. Any statement part which is not 
+    # `#graph_name` to those of `other`. Any statement part which is not
     # present in `self` is ignored.
     #
     # @example
     #   statement = RDF::Statement.new(RDF::URI('s'), RDF::URI('p'), RDF::URI('o'))
     #   pattern   = RDF::Statement.new(RDF::URI('s'), RDF::URI('p'), RDF::Query::Variable.new)
-    #   
+    #
     #   # true
     #   statement === statement
     #   pattern   === statement
     #   RDF::Statement.new(nil, nil, nil) === statement
-    # 
+    #
     #   # false
     #   statement === pattern
     #   statement === RDF::Statement.new(nil, nil, nil)

--- a/spec/model_list_spec.rb
+++ b/spec/model_list_spec.rb
@@ -585,6 +585,20 @@ describe RDF::List do
     it "returns true when comparing a list to its contents" do
       expect(ten).to eq ten.to_a
     end
+
+    it "returns false when comparing to non-list Values" do
+      expect(ten).not_to eq ten.subject
+      expect(ten).not_to eq ten.statements.first
+      expect(ten).not_to eq RDF::Node.new
+      expect(ten).not_to eq RDF::Graph.new
+    end
+    
+    it "returns false when comparing to similar statements" do
+      statement      = RDF::Statement(:s, :p, :o)
+      quasistatement = RDF::List[:s, :p, :o]
+      
+      expect(quasistatement).not_to eq statement
+    end
   end
 
   describe "#empty?" do

--- a/spec/model_statement_spec.rb
+++ b/spec/model_statement_spec.rb
@@ -207,6 +207,10 @@ describe RDF::Statement do
       expect(subject).not_to equal RDF::Statement.new s, p, o
       expect(subject).to equal subject
     end
+
+    it "is not == a RDF::List" do
+      expect(subject).not_to eq RDF::List[*subject]
+    end
   end
 
   context "completness" do


### PR DESCRIPTION
Ruby 2.3.0 changed the behavior of [`Comparable#==`](https://bugs.ruby-lang.org/issues/7688) to avoid hiding errors. This led to `NoMethodError`s for comparisons that return `false` for previous Rubies.

This introduces a custom `RDF::List#==` implementation for explicitly supported comparisons between `RDF::Value` classes. We return `false` immediately for `RDF::Value`s which are not `#list?`; falling back on `Comparable` for other types.

Further, `RDF::List`s with three elements that happen to coincide with the terms of an RDF::Statement would previously return `true`. E.g.: `RDF::List[:s, :p, :o] == RDF::Statement(:s, :p, :o)`. This unusual edge case is patched by way of the changes described above.

A similar change is made to `RDF::Statement#==` to preserve symmetry.

Closes #304 

