### PR TITLE
Adjust `List#<=>` to avoid error cases

### DIFF
--- a/lib/rdf/model/list.rb
+++ b/lib/rdf/model/list.rb
@@ -452,7 +452,7 @@ module RDF
     # @return [Integer]
     # @see    http://ruby-doc.org/core-2.2.2/Array.html#method-i-3C-3D-3E
     def <=>(other)
-      to_a <=> other.to_a # TODO: optimize this
+      to_a <=> Array(other)
     end
 
     ##

--- a/spec/model_list_spec.rb
+++ b/spec/model_list_spec.rb
@@ -571,6 +571,10 @@ describe RDF::List do
     it "returns 0 when given the same list" do
       expect(ten).to eq ten
     end
+
+    it "returns 0 when given the same list as array" do
+      expect(ten).to eq ten.to_a
+    end
   end
 
   describe "#==" do
@@ -591,8 +595,10 @@ describe RDF::List do
       expect(ten).not_to eq ten.statements.first
       expect(ten).not_to eq RDF::Node.new
       expect(ten).not_to eq RDF::Graph.new
+      expect(ten).not_to eq RDF::Literal.new('')
+      expect(ten).not_to eq Object.new
     end
-    
+
     it "returns false when comparing to similar statements" do
       statement      = RDF::Statement(:s, :p, :o)
       quasistatement = RDF::List[:s, :p, :o]


### PR DESCRIPTION
Using `Array(other)` instead of `other.to_a` avoids throwing errors when comparing. This minor tweak slightly improves the solution to #304 given in #305.