### PR TITLE
Implement `Transaction#mutated?`

### DIFF
--- a/lib/rdf/repository.rb
+++ b/lib/rdf/repository.rb
@@ -550,6 +550,14 @@ module RDF
         end
         
         ##
+        # @note this is a simple object equality check.
+        # 
+        # @see RDF::Transaction#mutated?
+        def mutated?
+          !@snapshot.send(:data).equal?(repository.send(:data))
+        end
+        
+        ##
         # Replaces repository data with the transaction's snapshot in a safely 
         # serializable fashion.
         # 

--- a/lib/rdf/transaction.rb
+++ b/lib/rdf/transaction.rb
@@ -157,6 +157,29 @@ module RDF
     end
 
     ##
+    # Indicates whether the transaction includes changes relative to the target 
+    # repository's state at transaction start time.
+    #
+    # The response is guaranteed to be `true` if executing the transaction 
+    # against the original repository state would cause a change. It may also
+    # return `true` in cases where the repository would not change (e.g. 
+    # because the transaction would insert statements already present). 
+    #
+    # @note `Transaction` implementers may choose to `NotImplementedError`
+    #   if the transaction implementation cannot be implemented efficiently.
+    #
+    # @return [Boolean] true if the transaction has mutated (insert/delete) 
+    #   since transaction start time
+    #
+    # @raise [NotImplementedError] if a mutation check is not implemented
+    def mutated?
+      return !changes.empty? if self.class == Transaction
+
+      raise NotImplementedError, 
+            '#mutated? is not implemented for #{self.class}'
+    end
+
+    ##
     # Returns `true` if this is a read/write transaction, `false` otherwise.
     #
     # @return [Boolean]

--- a/spec/transaction_spec.rb
+++ b/spec/transaction_spec.rb
@@ -58,6 +58,16 @@ describe RDF::Transaction do
       end
     end
 
+    describe 'mutated?' do
+      it 'raises an error for subclasses' do
+        class MyTx < described_class; end
+
+        tx = MyTx.new(repository)
+
+        expect { tx.mutated? }.to raise_error NotImplementedError
+      end
+    end
+
     describe '#execute' do
       it 'calls `changes#apply` with repository' do
         expect(subject.changes).to receive(:apply).with(subject.repository)


### PR DESCRIPTION
`#mutated?` must return `true` when the transaction would change the
repository if executed against it's state at transaction start time.
We allow implementations to return `true` in other cases, as well; there
is no guarantee that a `false` result will be returned in any specific
circumstances (or ever).

For the base transaction, we simply check whether `@changes` is
empty. This can give false positives, but avoids a worst-case linear
check.

For subclasses with no custom implementation, we raise a
`NotImplementedError`.

For the `SerializableTransaction` included in the default
`Repository::Implementation`, we use `#equal?` on the `Hamster::Hash`
instances. This will always give a correct response for the actual
implementation, moreover, it is guaranteed not to give false negatives
even if a user messes with the snapshot using `#send`.

Closes #308.