### PR TITLE
Avoid expensive hash comparison on Hamster::Hash

### DIFF
--- a/lib/rdf/repository.rb
+++ b/lib/rdf/repository.rb
@@ -574,11 +574,9 @@ module RDF
           raise TransactionError, 'Cannot execute a rolled back transaction. ' \
                                   'Open a new one instead.' if @rolledback
 
-          # `Hamster::Hash#==` will use a cheap `#equal?` check first, but fall 
-          # back on a full Ruby Hash comparison if required.
           raise TransactionError, 'Error merging transaction. Repository' \
                                   'has changed during transaction time.' unless 
-            repository.send(:data) == @base_snapshot.send(:data)
+            repository.send(:data).equal? @base_snapshot.send(:data)
 
           repository.send(:data=, @snapshot.send(:data))
         end


### PR DESCRIPTION
In practice, these objects are either `#equal?` or won't be `#==`. This avoids potentially expensive `#to_hash` calls and comparisons.