### PR TITLE
Remove `wirble` development dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,6 @@ end
 
 group :debug do
   gem 'psych', platforms: [:mri, :rbx]
-  gem "wirble"
   gem "redcarpet", platforms: :ruby
   gem "byebug", platforms: :mri
   gem 'rubinius-debugger', platform: :rbx


### PR DESCRIPTION
`wirble` doesn't seem to have a license.