### PR TITLE
Ignore false positive dependency issue on `rdf-isomorphic`

### DIFF
--- a/dependencyci.yml
+++ b/dependencyci.yml
@@ -1,0 +1,5 @@
+platform:
+  Rubygems:
+    rdf-isomorphic:
+      tests:
+        unmaintained: skip


### PR DESCRIPTION
For some reason Libraries.io thinks this is unmaintained. We've contacted them about a correction, but silencing Dependency CI on this issue in the meanwhile.