### PR TITLE
Define RDF::Statement#hash to support comparison operations in e.g. Array#-

### DIFF
--- a/lib/rdf/model/statement.rb
+++ b/lib/rdf/model/statement.rb
@@ -242,6 +242,12 @@ module RDF
     end
 
     ##
+    # Generates a Fixnum hash value as a quad.
+    def hash
+      @hash ||= to_quad.hash
+    end
+
+    ##
     # Checks statement equality as a triple.
     #
     # @param  [Object] other

--- a/lib/rdf/model/statement.rb
+++ b/lib/rdf/model/statement.rb
@@ -351,6 +351,7 @@ module RDF
       self.object.canonicalize!     if has_object? && !self.object.frozen?
       self.graph_name.canonicalize! if has_graph? && !self.graph_name.frozen?
       self.validate!
+      @hash = nil
       self
     end
 

--- a/lib/rdf/model/uri.rb
+++ b/lib/rdf/model/uri.rb
@@ -382,6 +382,7 @@ module RDF
         fragment: normalized_fragment
       }
       @value = nil
+      @hash = nil
       self
     end
     alias_method :normalize!, :canonicalize!

--- a/spec/model_statement_spec.rb
+++ b/spec/model_statement_spec.rb
@@ -211,6 +211,8 @@ describe RDF::Statement do
     it "is not == a RDF::List" do
       expect(subject).not_to eq RDF::List[*subject]
     end
+
+    specify {expect(RDF::Statement(:s, p, o).hash).to eq (RDF::Statement(:s, p, o).hash)}
   end
 
   context "completness" do

--- a/spec/model_uri_spec.rb
+++ b/spec/model_uri_spec.rb
@@ -467,6 +467,7 @@ describe RDF::URI do
       it "#canonicalize #{name}" do
         u1 = RDF::URI(input)
         u2 = RDF::URI(output)
+        expect(u1.canonicalize.hash).to eq u2.hash
         expect(u1.canonicalize.to_s).to eq u2.to_s
         expect(u1).to eq u1
       end


### PR DESCRIPTION
@revgum reported an issue using `Array#-`, e.g.:

```ruby
a = RDF::Statement.new
b = RDF::Statement.new

# ACTUAL
[a] - [b] # => [#<RDF::Statement:0x3ffcd516003c(nil nil nil .)>]

# EXPECTED
[a] - [b] # => []
```

4ac2e7 revealed a bug in how memoized hash values were handled with `#canonicalize!`, fixed by 6270164.