### PR TITLE
Dispatch `Enumerator#to_ary` with alias

### DIFF
--- a/lib/rdf/mixin/enumerator.rb
+++ b/lib/rdf/mixin/enumerator.rb
@@ -7,14 +7,11 @@ module RDF
       include Queryable
       include Enumerable
 
-      def method_missing(method, *args)
-        self.to_a if method.to_sym == :to_ary
-      end
-
       # Make sure returned arrays are also queryable
       def to_a
         return super.to_a.extend(RDF::Queryable, RDF::Enumerable)
       end
+      alias_method :to_ary, :to_a
     end
   end
 


### PR DESCRIPTION
There's no need to use `#method_missing` to dispatch this.

Preferring `alias_method` over `alias`, contrary to [Ruby Style Guide](https://github.com/bbatsov/ruby-style-guide). We want dynamic dispatch of the aliased method.