### PR TITLE
Inherit the correct isolation level with #snapshot

### DIFF
--- a/lib/rdf/repository.rb
+++ b/lib/rdf/repository.rb
@@ -212,7 +212,7 @@ module RDF
     ##
     # @see RDF::Dataset#isolation_level
     def isolation_level
-      supports?(:snapshot) ? :repeatable_read : super
+      supports?(:snapshots) ? :repeatable_read : super
     end
 
     ##


### PR DESCRIPTION
Fix a typo in `RDF::Repository#isolation_level` to inherit the correct level when snapshot is implemented. This affects Repositories implementing snapshots, but not overriding the default `#isolation_level`.