### PR TITLE
Feature/vocab utils

### DIFF
--- a/lib/rdf/model/literal.rb
+++ b/lib/rdf/model/literal.rb
@@ -409,6 +409,30 @@ module RDF
     end
 
     ##
+    # Returns the literal, first removing all whitespace on both ends of the value, and then changing remaining consecutive whitespace groups into one space each.
+    #
+    # Note that it handles both ASCII and Unicode whitespace.
+    #
+    # @see [String#squish](http://apidock.com/rails/String/squish)
+    # @return [RDF::Literal] a new literal based on `self`.
+    def squish(*other_string)
+      self.dup.squish!
+    end
+
+    ##
+    # Performs a destructive {#squish}.
+    #
+    # @see [String#squish!](http://apidock.com/rails/String/squish%21)
+    # @return self
+    def squish!
+      @string = value.
+        gsub(/\A[[:space:]]+/, '').
+        gsub(/[[:space:]]+\z/, '').
+        gsub(/[[:space:]]+/, ' ')
+      self
+    end
+
+    ##
     # Escape a literal using ECHAR escapes.
     #
     #    ECHAR ::= '\' [tbnrf"'\]

--- a/lib/rdf/vocabulary.rb
+++ b/lib/rdf/vocabulary.rb
@@ -321,13 +321,18 @@ module RDF
       #
       # @param [RDF::Enumerable] graph
       # @param [URI, #to_s] url
-      # @param [String] class_name
-      #   The class_name associated with the vocabulary, used for creating the class name of the vocabulary. This will create a new class named with a top-level constant based on `class_name`.
+      # @param [RDF::Vocabulary, String] class_name
+      #   The class_name associated with the vocabulary, used for creating the class name of the vocabulary. This will create a new class named with a top-level constant based on `class_name`. If given an existing vocabulary, it replaces the existing definitions for that vocabulary with those from the graph.
       # @param [Array<Symbol>, Hash{Symbol => Hash}] extra
       #   Extra terms to add to the vocabulary. In the first form, it is an array of symbols, for which terms are created. In the second, it is a Hash mapping symbols to property attributes, as described in {RDF::Vocabulary.property}.
       # @return [RDF::Vocabulary] the loaded vocabulary
       def from_graph(graph, url: nil, class_name: nil, extra: nil)
-        vocab = if class_name
+        vocab = case class_name
+        when RDF::Vocabulary
+          class_name.instance_variable_set(:@ontology, nil)
+          class_name.instance_variable_set(:@properties, nil)
+          class_name
+        when String
           Object.const_set(class_name, Class.new(self.create(url)))
         else
           Class.new(self.create(url))

--- a/spec/model_literal_spec.rb
+++ b/spec/model_literal_spec.rb
@@ -248,7 +248,6 @@ describe RDF::Literal do
     end
   end
 
-
   describe "#compatible?" do
     {
       %("abc") => {
@@ -283,6 +282,32 @@ describe RDF::Literal do
           end
         end
       end
+    end
+  end
+
+  describe "#squish" do
+    let(:result) {"a b c"}
+    subject {RDF::Literal("  a\n b  c\n  ")}
+
+    it "squeezes properly" do
+      expect(subject.squish).to eq result
+    end
+
+    it "returns a new object" do
+      expect(subject.squish).not_to equal subject
+    end
+  end
+
+  describe "#squish!" do
+    let(:result) {"a b c"}
+    subject {RDF::Literal("  a\n b  c\n  ")}
+
+    it "squeezes properly" do
+      expect(subject.squish!).to eq result
+    end
+
+    it "returns itself" do
+      expect(subject.squish!).to equal subject
     end
   end
 

--- a/spec/vocabulary_spec.rb
+++ b/spec/vocabulary_spec.rb
@@ -328,8 +328,11 @@ describe RDF::Vocabulary do
     let!(:graph) {
       RDF::Graph.new << RDF::NTriples::Reader.new(nt)
     }
+    let!(:vocab) {
+      @vocab ||= RDF::Vocabulary.from_graph(graph, url: "http://example/")
+    }
 
-    subject {RDF::Vocabulary.from_graph(graph, url: "http://example/")}
+    subject {@vocab}
 
     it "creates terms" do
       expect(subject).to be_a_vocabulary("http://example/")
@@ -341,6 +344,28 @@ describe RDF::Vocabulary do
 
       it "adds extra properties to vocabulary" do
         expect(subject).to have_properties("http://example/", %w(id))
+      end
+    end
+
+    context "with existing Vocabulary" do
+      let!(:nt) {%{
+        <http://example/Klass> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .
+        <http://example/Klass> <http://www.w3.org/2000/01/rdf-schema#Datatype> "Class" .
+        <http://example/pr0p> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> .
+        <http://example/pr0p> <http://www.w3.org/2000/01/rdf-schema#Datatype> "pr0p" .
+      }}
+      let!(:graph) {
+        RDF::Graph.new << RDF::NTriples::Reader.new(nt)
+      }
+      subject {RDF::Vocabulary.from_graph(graph, url: "http://example/", class_name: vocab)}
+
+      it "creates terms" do
+        expect(subject).to be_a_vocabulary("http://example/")
+        expect(subject).to have_properties("http://example/", %w(Klass pr0p))
+      end
+
+      it "removes old terms" do
+        expect(subject).not_to have_properties("http://example/", %w(Class prop))
       end
     end
   end


### PR DESCRIPTION
Updates for vocabulary manipulation, and string squeezing in literals. (Squeezing literals before doing comparison allows for differences in fields such as `rdfs:comment` which may differ due to nominal serialization differences).