### PR TITLE
Add `Format.accept_types` and `Format.accept_type`.

### DIFF
--- a/lib/rdf/nquads.rb
+++ b/lib/rdf/nquads.rb
@@ -20,7 +20,7 @@ module RDF
     # @see http://www.w3.org/TR/n-quads/
     # @since  0.4.0
     class Format < RDF::Format
-      content_type     'application/n-quads', extension: :nq, alias: ['text/x-nquads']
+      content_type     'application/n-quads', extension: :nq, alias: 'text/x-nquads;q=0.2'
       content_encoding 'utf-8'
 
       reader { RDF::NQuads::Reader }

--- a/lib/rdf/ntriples/format.rb
+++ b/lib/rdf/ntriples/format.rb
@@ -16,7 +16,7 @@ module RDF::NTriples
   # @see http://www.w3.org/TR/rdf-testcases/#ntriples
   # @see http://www.w3.org/TR/n-triples/
   class Format < RDF::Format
-    content_type     'application/n-triples', extension: :nt, alias: ['text/plain']
+    content_type     'application/n-triples', extension: :nt, alias: 'text/plain;q=0.2'
     content_encoding 'utf-8'
 
     reader { RDF::NTriples::Reader }

--- a/lib/rdf/util/file.rb
+++ b/lib/rdf/util/file.rb
@@ -39,24 +39,7 @@ module RDF; module Util
       ##
       # @return [String] the value for an Accept header
       def self.default_accept_header
-        # Receive text/html and text/plain at a lower priority than other formats. Also special cases for other formats.
-        # TODO: Associate priority level when setting `content_type` and use in an alternative to `reader_types`, or to simply change `reader_types`.
-        reader_types = RDF::Format.reader_types.map do |t|
-          case t.to_s
-          when /text\/plain/
-            "#{t};q=0.2"
-          when /text\/(?:csv|tab-separated-values)/
-            "#{t};q=0.4"
-          when /text\/html/
-            "#{t};q=0.5"
-          when /application\/xhtml\+xml/
-            "#{t};q=0.7"
-          else
-            t
-          end
-        end
-
-        (reader_types + %w(*/*;q=0.1)).join(", ")
+        (RDF::Format.accept_types + %w(*/*;q=0.1)).join(", ")
       end
       
       ##

--- a/spec/format_spec.rb
+++ b/spec/format_spec.rb
@@ -4,7 +4,8 @@ require 'rdf/ntriples'
 require 'rdf/nquads'
 
 class RDF::Format::FooFormat < RDF::Format
-  content_type     'application/test', extension: :test
+  content_type     'application/test;q=1',
+                   extension: :test
   reader { RDF::NTriples::Reader }
   def self.detect(sample)
     sample == "foo"
@@ -13,7 +14,9 @@ class RDF::Format::FooFormat < RDF::Format
 end
 
 class RDF::Format::BarFormat < RDF::Format
-  content_type     'application/test', extension: :test
+  content_type     'application/test',
+                   extension: :test,
+                   alias: 'application/x-test;q=0.1'
   reader { RDF::NTriples::Reader }
   def self.detect(sample)
     sample == "bar"
@@ -68,13 +71,21 @@ describe RDF::Format do
 
   describe ".reader_types" do
     it "returns content-types of available readers" do
-      %w(
+      expect(RDF::Format.reader_types).to include(*%w(
         application/n-triples text/plain
         application/n-quads text/x-nquads
-        application/test
-      ).each do |ct|
-        expect(RDF::Format.reader_types).to include(ct)
-      end
+        application/test application/x-test
+      ))
+    end
+  end
+
+  describe ".accept_types" do
+    it "returns accept-types of available readers with quality" do
+      expect(RDF::Format.accept_types).to include(*%w(
+        application/n-triples text/plain;q=0.2
+        application/n-quads text/x-nquads;q=0.2
+        application/test application/x-test;q=0.1
+      ))
     end
   end
 

--- a/spec/util_file_spec.rb
+++ b/spec/util_file_spec.rb
@@ -31,7 +31,7 @@ describe RDF::Util::File do
     describe ".default_accept_header" do
       subject { RDF::Util::File::HttpAdapter.default_accept_header.split(", ") }
       before do
-        allow(RDF::Format).to receive(:reader_types).and_return(["text/html", "text/plain", "application/xhtml+xml", "text/csv", "text/tab-separated-values"])
+        allow(RDF::Format).to receive(:accept_types).and_return(["text/html;q=0.5", "text/plain;q=0.2", "application/xhtml+xml;q=0.7", "text/csv;q=0.4", "text/tab-separated-values;q=0.4"])
       end
       it "should demote text/plain to q=0.2" do
         expect(subject).to include "text/plain;q=0.2"


### PR DESCRIPTION
This allows `Format.content_type` to be provided with priority parameters for the `type`, and `aliases`. These are stripped out to allow `Format.reader_types` and so-forth, to continue to return values without parameters.

Fixes #327.