### PR TITLE
Make Dataset concrete

### DIFF
--- a/lib/rdf/model/dataset.rb
+++ b/lib/rdf/model/dataset.rb
@@ -2,22 +2,83 @@ module RDF
   ##
   # An RDF Dataset
   #
-  # Datasets are immutable by default. {RDF::Repository} provides an interface 
+  # Datasets are immutable by default. {RDF::Repository} provides an interface
   # for mutable Datasets.
-  # 
+  #
+  # A Dataset functions as an a set of named RDF graphs with a default graph.
+  # It implements {RDF::Enumerable} and {RDF::Queryable} over the whole set;
+  # if no specific graph name is queried, enumerating and querying takes place
+  # over the intersection of all the graphs in the Dataset.
+  #
+  # The default graph is named with a constant `DEFAULT_GRAPH`.
+  #
+  # @example initializing an RDF::Dataset with existing data
+  #   statements = [RDF::Statement.new(RDF::URI(:s), RDF::URI(:p), :o)]
+  #   dataset    = RDF::Dataset.new(statements: statements)
+  #   dataset.count # => 1
+  #
   # @see https://www.w3.org/TR/rdf11-concepts/#section-dataset
   # @see https://www.w3.org/TR/rdf11-datasets/
   class Dataset
-    include RDF::Countable
     include RDF::Enumerable
     include RDF::Durable
     include RDF::Queryable
 
-    ISOLATION_LEVELS = [ :read_uncommitted, 
-                         :read_committed, 
-                         :repeatable_read, 
-                         :snapshot, 
-                         :serializable].freeze
+    DEFAULT_GRAPH = false
+
+    ISOLATION_LEVELS = [ :read_uncommitted,
+                         :read_committed,
+                         :repeatable_read,
+                         :snapshot,
+                         :serializable ].freeze
+
+    ##
+    # @param [RDF::Enumerable, Array<RDF::Statement>] statements  the initial 
+    #   contents of the dataset
+    # @yield [dataset] yields itself when a block is given
+    # @yieldparam [RDF::Dataset] dataset
+    def initialize(statements: [], **options, &block)
+      @statements = statements.map do |s| 
+        s = s.dup
+        s.graph_name ||= DEFAULT_GRAPH
+        s.freeze
+      end.freeze
+
+      if block_given?
+        case block.arity
+          when 1 then yield self
+          else instance_eval(&block)
+        end
+      end
+    end
+
+    ##
+    # @private
+    # @see RDF::Durable#durable?
+    def durable?
+      false
+    end
+
+    ##
+    # @private
+    # @see RDF::Enumerable#each_statement
+    def each_statement
+      if block_given?
+        @statements.each do |st| 
+          if st.graph_name.equal?(DEFAULT_GRAPH)
+            st = st.dup
+            st.graph_name = nil
+          end
+
+          yield st
+        end
+
+        self
+      end
+
+      enum_statement 
+    end
+    alias_method :each, :each_statement
 
     ##
     # Returns a developer-friendly representation of this object.
@@ -36,13 +97,42 @@ module RDF
       each_statement { |statement| statement.inspect! }
       nil
     end
-    
+
     ##
     # @return [Symbol] a representation of the isolation level for reads of this
-    #   Dataset. One of `:read_uncommitted`, `:read_committed`, `:repeatable_read`, 
+    #   Dataset. One of `:read_uncommitted`, `:read_committed`, `:repeatable_read`,
     #  `:snapshot`, or `:serializable`.
     def isolation_level
       :read_committed
+    end
+
+    ##
+    # @private
+    # @see RDF::Enumerable#supports?
+    def supports?(feature)
+      return true if feature == :graph_name
+      super
+    end
+
+    protected
+    
+    ##
+    # Implements basic query pattern matching over the Dataset, with handling 
+    # for a default graph.
+    def query_pattern(pattern, options = {}, &block)
+      return super unless pattern.graph_name == DEFAULT_GRAPH
+
+      if block_given?
+        pattern = pattern.dup
+        pattern.graph_name = nil
+
+        each_statement do |statement|
+          yield statement if (statement.graph_name == DEFAULT_GRAPH ||
+                              statement.graph_name.nil?) && pattern === statement
+        end
+      else
+        enum_for(:query_pattern, pattern, options)
+      end
     end
   end
 end

--- a/lib/rdf/model/statement.rb
+++ b/lib/rdf/model/statement.rb
@@ -140,7 +140,7 @@ module RDF
       !(has_subject?    && subject.resource? &&
         has_predicate?  && predicate.resource? &&
         has_object?     && (object.resource? || object.literal?) &&
-        (has_graph?     ? graph_name.resource? : true ))
+        (has_graph?     ? graph_name.resource? : true))
     end
 
     ##
@@ -155,7 +155,7 @@ module RDF
       has_subject?    && subject.resource? && subject.valid? &&
       has_predicate?  && predicate.uri? && predicate.valid? &&
       has_object?     && object.term? && object.valid? &&
-      (has_graph?      ? graph_name.resource? && graph_name.valid? : true )
+      (has_graph?      ? (graph_name.resource? && graph_name.valid?) : true)
     end
 
     ##

--- a/lib/rdf/query/pattern.rb
+++ b/lib/rdf/query/pattern.rb
@@ -104,7 +104,7 @@ module RDF; class Query
       (has_subject?   ? (subject.resource? || subject.variable?) && subject.valid? : true) && 
       (has_predicate? ? (predicate.uri? || predicate.variable?) && predicate.valid? : true) &&
       (has_object?    ? (object.term? || object.variable?) && object.valid? : true) &&
-      (has_graph?     ? (graph_name.resource? || graph_name.variable?) && graph_name.valid? : true )
+      (has_graph?     ? (graph_name.resource? || graph_name.variable?) && graph_name.valid? : true)
     rescue NoMethodError
       false
     end

--- a/lib/rdf/repository.rb
+++ b/lib/rdf/repository.rb
@@ -283,13 +283,6 @@ module RDF
       
       ##
       # @private
-      # @see RDF::Durable#durable?
-      def durable?
-        false
-      end
-      
-      ##
-      # @private
       # @see RDF::Enumerable#has_graph?      
       def has_graph?(graph)
         @data.has_key?(graph)
@@ -388,7 +381,7 @@ module RDF
 
           cs.each do |c, ss|
             next unless graph_name.nil? ||
-                        graph_name == false && !c ||
+                        graph_name == DEFAULT_GRAPH && !c ||
                         graph_name.eql?(c)
 
             ss = if subject.nil? || subject.is_a?(RDF::Query::Variable)

--- a/spec/dataset_spec.rb
+++ b/spec/dataset_spec.rb
@@ -1,0 +1,77 @@
+require File.join(File.dirname(__FILE__), 'spec_helper')
+require 'rdf/spec/dataset'
+
+describe RDF::Dataset do
+  describe 'initializing' do
+    it 'yields itself' do
+      expect { |b| described_class.new(&b) }.to yield_control
+    end
+
+    context 'with statemens' do
+      let(:statements) { RDF::Spec.quads }
+
+      it 'accepts statements as array' do
+        expect(described_class.new(statements: [*statements]))
+          .to contain_exactly(*statements)
+      end
+
+      it 'accepts statements as RDF::Enumerable' do
+        statements.extend(RDF::Enumerable)
+
+        expect(described_class.new(statements: statements))
+          .to contain_exactly(*statements)
+      end
+    end
+  end
+  
+  context 'default empty dataset' do
+    it { is_expected.to be_empty }
+
+    describe '#each' do
+      it 'is an empty enumerator' do
+        expect(subject.each).to contain_exactly()
+      end
+    end
+
+    describe '#supports?' do
+      [:validity, :literal_equality, :graph_name].each do |key|
+        it "supports #{key}" do
+          expect(subject.supports?(key)).to be true
+        end
+      end
+
+      [:inference, :skolemize].each do |key|
+        it "does not support #{key}" do
+          expect(subject.supports?(key)).to be false
+        end
+      end
+
+      it 'does not support abitrary keys' do
+        expect(subject.supports?(:moomin)).to be false
+      end
+    end
+  end
+
+  context 'with statements' do
+    let(:statements) { RDF::Spec.quads }
+
+    it_behaves_like 'an RDF::Dataset' do
+      let(:dataset) { RDF::Dataset.new(statements: statements) }
+
+      describe '#query_pattern' do
+        let(:graph_name) { subject.singleton_class::DEFAULT_GRAPH }
+
+        it "returns statements from unnamed graphs with default graph_name" do
+          pattern = RDF::Query::Pattern.new(nil, nil, nil, graph_name: graph_name)
+          solutions = []
+          subject.send(:query_pattern, pattern) {|s| solutions << s}
+          
+          unnamed_statements = subject.statements
+          unnamed_statements.reject! {|st| st.has_name?}
+
+          expect(solutions.size).to eq unnamed_statements.size
+        end
+      end
+    end
+  end
+end

--- a/spec/mixin_queryable_spec.rb
+++ b/spec/mixin_queryable_spec.rb
@@ -4,11 +4,7 @@ require 'rdf/spec/queryable'
 describe RDF::Queryable do
   # @see lib/rdf/spec/queryable.rb in rdf-spec
   it_behaves_like 'an RDF::Queryable' do
-    # The available reference implementations are `RDF::Repository` and
-    # `RDF::Graph`, but a subclass of Ruby Array implementing
-    # `query_pattern` and `query_execute` should do as well
-    # FIXME
-    let(:queryable) { RDF::Repository.new }
+    let(:queryable) { RDF::Spec.quads.extend(RDF::Enumerable, RDF::Queryable) }
   end
 
   context "Examples" do

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -2,7 +2,6 @@ require File.join(File.dirname(__FILE__), 'spec_helper')
 require 'rdf/spec/repository'
 
 describe RDF::Repository do
-
   # @see lib/rdf/spec/repository.rb in rdf-spec
   it_behaves_like 'an RDF::Repository' do
     let(:repository) { RDF::Repository.new }
@@ -37,6 +36,23 @@ describe RDF::Repository do
       expect do
         begin; subject.apply_changeset(changeset) rescue ArgumentError; end;
       end.not_to change { subject.statements }
+    end
+  end
+
+  describe '#query_pattern' do
+    before { subject.insert(*RDF::Spec.quads) }
+
+    let(:graph_name) { subject.singleton_class::DEFAULT_GRAPH }
+
+    it "returns statements from unnamed graphs with default graph_name" do
+      pattern = RDF::Query::Pattern.new(nil, nil, nil, graph_name: graph_name)
+      solutions = []
+      subject.send(:query_pattern, pattern) {|s| solutions << s}
+      
+      unnamed_statements = subject.statements
+      unnamed_statements.reject! {|st| st.has_name?}
+
+      expect(solutions.size).to eq unnamed_statements.size
     end
   end
 end


### PR DESCRIPTION
RDF::Dataset previously served as little more than an abstract
class. Instantiating one was possible, but didn't provide any useful
functionality. This implements a basic `RDF::Dataset` as an
`Enumerable`/`Queryable` over a static dataset specified at
initialization.

Clarifies handling of the default graph, adopting the ususal definition
of an RDF/SPARQL dataset for `RDF::Dataset` and its
subclasses (e.g. `RDF::Repository`). Normal `Enumerable`/`Queryable`
objects continue to *not* behave like RDF datasets. The accompanying
changes to `rdf-spec` reflect this while running the shared examples
over such a generic `Queryable`.

Depends on https://github.com/ruby-rdf/rdf-spec/pull/64

Closes #318 