### PR TITLE
Changes to implicit/explicit type conversions

### DIFF
--- a/lib/rdf/mixin/enumerator.rb
+++ b/lib/rdf/mixin/enumerator.rb
@@ -7,11 +7,29 @@ module RDF
       include Queryable
       include Enumerable
 
-      # Make sure returned arrays are also queryable
+      ##
+      # @return [Array]
+      # @note Make sure returned arrays are also queryable
       def to_a
         return super.to_a.extend(RDF::Queryable, RDF::Enumerable)
       end
-      alias_method :to_ary, :to_a
+
+      protected
+
+      ##
+      # @overload #to_ary
+      #   @see #to_a
+      #   @deprecated use {#to_a} instead
+      def method_missing(name, *args)
+        if name == :to_ary
+          warn "[DEPRECATION] #{self.class}#to_ary is deprecated, use " \
+               "#{self.class}#to_a instead. Called from " \
+               "#{Gem.location_of_caller.join(':')}"
+          to_a
+        else
+          super
+        end
+      end
     end
   end
 
@@ -28,11 +46,29 @@ module RDF
       include Queryable
       include Enumerable
 
-      # Make sure returned arrays are also queryable
+      ##
+      # @return [Array]
+      # @note Make sure returned arrays are also queryable
       def to_a
         return super.to_a.extend(RDF::Queryable, RDF::Enumerable)
       end
-      alias_method :to_ary, :to_a
+
+      protected
+
+      ##
+      # @overload #to_ary
+      #   @see #to_a
+      #   @deprecated use {#to_a} instead
+      def method_missing(name, *args)
+        if name == :to_ary
+          warn "[DEPRECATION] #{self.class}#to_ary is deprecated, use " \
+               "#{self.class}#to_a instead. Called from " \
+               "#{Gem.location_of_caller.join(':')}"
+          self.to_a
+        else
+          super
+        end
+      end
     end
   end
 end

--- a/lib/rdf/model/literal.rb
+++ b/lib/rdf/model/literal.rb
@@ -477,5 +477,27 @@ module RDF
     def inspect
       sprintf("#<%s:%#0x(%s)>", self.class.name, __id__, RDF::NTriples.serialize(self))
     end
+
+    protected
+
+    ##
+    # @overload #to_str
+    #   This method is implemented when the datatype is `xsd:string` or `rdf:langString`
+    #   @return [String]
+    def method_missing(name, *args)
+      case name
+      when :to_str
+        return to_s if @datatype == RDF.langString || @datatype == RDF::XSD.string
+      end
+      super
+    end
+
+    def respond_to_missing?(name, include_private = false)
+      case name
+      when :to_str
+        return true if @datatype == RDF.langString || @datatype == RDF::XSD.string
+      end
+      super
+    end
   end # Literal
 end # RDF

--- a/lib/rdf/model/statement.rb
+++ b/lib/rdf/model/statement.rb
@@ -337,9 +337,14 @@ module RDF
     def to_triple
       [subject, predicate, object]
     end
+    alias_method :to_a, :to_triple
 
-    alias_method :to_a,   :to_triple
-    alias_method :to_ary, :to_triple
+    ##
+    # @deprecated use {#to_a} or {#to_triple} instead
+    # @see #to_triple
+    def to_ary
+      to_triple
+    end
 
     ##
     # Canonicalizes each unfrozen term in the statement

--- a/spec/model_literal_spec.rb
+++ b/spec/model_literal_spec.rb
@@ -221,6 +221,30 @@ describe RDF::Literal do
     end
   end
 
+  # to_str is implemented for stringy xsd types, but not others
+  describe "#to_str" do
+    literals(:all_plain).each do |args|
+      it "is implemented for #{args.inspect}" do
+        expect(RDF::Literal.new(*args)).to respond_to :to_str
+      end
+
+      it "matches #to_s for #{args.inspect}" do
+        literal = RDF::Literal.new(*args)
+        expect(literal.to_str).to eq literal.to_s
+      end
+    end
+
+    (literals(:all) - literals(:all_plain)).each do |args|
+      it "is not implemented for #{args.inspect}" do
+        expect(RDF::Literal.new(*args)).not_to respond_to :to_str
+      end
+
+      it "raises NoMethodError for #{args.inspect}" do
+        expect { RDF::Literal.new(*args).to_str }.to raise_error NoMethodError
+      end
+    end
+  end
+
   describe "#object" do
     literals(:all_plain).each do |args|
       it "returns value for #{args.inspect}" do


### PR DESCRIPTION
Deprecates `#to_ary` from `Enumerator` and `Statement`. Note that `Statement#to_ary` does not raise deprecation warnings, since it will be called often in `Array(statement)`.

`Literal#to_str` is added for stringy literal datatypes.