### PR TITLE
Fixup Transaction documentation

### DIFF
--- a/lib/rdf/transaction.rb
+++ b/lib/rdf/transaction.rb
@@ -39,21 +39,21 @@ module RDF
   #   end
   # 
   # The base class provides an atomic write implementation depending on
-  # `RDF::Changeset` and using `Changeset#apply`. Custom `Repositories`
+  # {RDF::Changeset} and using {Changeset#apply}. Custom {Repository} classes
   # can implement a minimial write-atomic transactions by overriding
-  # `#apply_changeset`.
+  # {#apply_changeset}.
   #
   # Reads within a transaction run against the live repository by default
-  # (`#isolation_level' is `:read_committed`). Repositories may provide support
-  # for snapshots by implementing `Repository#snapshot` and responding `true` to
+  # ({#isolation_level} is `:read_committed`). Repositories may provide support
+  # for snapshots by implementing {Repository#snapshot} and responding `true` to
   # `#supports?(:snapshots)`. In this case, the transaction will use the 
-  # `RDF::Dataset` returned by `#snapshot` for reads (`:repeatable_read`).
+  # {RDF::Dataset} returned by {#snapshot} for reads (`:repeatable_read`).
   #
   # For datastores that support transactions natively, implementation of a 
-  # custom `Transaction` subclass is recommended. The `Repository` is 
+  # custom {Transaction} subclass is recommended. The {Repository} is 
   # responsible for specifying snapshot support and isolation level as 
   # appropriate. Note that repositories may provide the snapshot isolation level
-  # without implementing `#snapshot`.
+  # without implementing {#snapshot}.
   #
   # @example A repository with a custom transaction class
   #  class MyRepository < RDF::Repository


### PR DESCRIPTION
There were some quote mismatches in Transaction documentation. These are fixed, and some YARD-style links are added.