### PR TITLE
Feature/issue 347 accept header

### DIFF
--- a/spec/ntriples_spec.rb
+++ b/spec/ntriples_spec.rb
@@ -8,13 +8,6 @@ require 'rdf/turtle'
 
 describe RDF::NTriples::Format do
 
-  # Restrict detected formats
-  before(:all) do
-    @formats = RDF::Format.class_variable_get(:@@subclasses)
-    RDF::Format.class_variable_set(:@@subclasses, [])
-  end
-  before(:all) {RDF::Format.class_variable_set(:@@subclasses, @formats)}
-
   # @see lib/rdf/spec/format.rb in rdf-spec
   it_behaves_like 'an RDF::Format' do
     let(:format_class) { described_class }

--- a/spec/reader_spec.rb
+++ b/spec/reader_spec.rb
@@ -1,0 +1,60 @@
+# -*- encoding: utf-8 -*-
+require File.join(File.dirname(__FILE__), 'spec_helper')
+require 'webmock/rspec'
+require 'rdf/ntriples'
+require 'rdf/nquads'
+require 'rdf/turtle'
+
+describe RDF::Reader do
+  describe ".each" do
+    it "enumerates formats having a reader" do
+      expect(described_class.each.to_a).to include(RDF::NTriples::Reader, RDF::NQuads::Reader, RDF::Turtle::Reader)
+    end
+
+    it "does not include RDF::Reader" do
+      expect(described_class.each.to_a & [RDF::Reader]).to be_empty
+    end
+  end
+
+  describe ".for" do
+    [
+      :ntriples,
+      'etc/doap.nt',
+      {file_name:      'etc/doap.nt'},
+      {file_extension: 'nt'},
+      {content_type:   'application/n-triples'},
+      {content_type:   'text/plain'},
+    ].each do |arg|
+      it "discovers with #{arg.inspect}" do
+        expect(RDF::Reader.for(arg)).to eq RDF::NTriples::Reader
+      end
+    end
+  end
+
+  describe ".format" do
+    it "returns nil if given no format" do
+      expect(described_class.format).to be_nil
+    end
+
+    it "returns nil if given a format" do
+      expect(described_class.format(:ntriples)).to be_nil
+    end
+  end
+
+  describe ".open" do
+    it "sets Accept header for all readers" do
+      uri = "http://example/foo"
+      accept = (RDF::Format.accept_types + %w(*/*;q=0.1)).join(", ")
+      reader_mock = double("reader")
+      expect(reader_mock).to receive(:got_here)
+      WebMock.stub_request(:get, uri).with do |request|
+        expect(request.headers['Accept']).to eql accept
+      end.to_return(body: "foo")
+
+      described_class.open(uri) do |r|
+        expect(r).to be_a(described_class)
+        reader_mock.got_here
+      end
+    end
+  end
+end

--- a/spec/readme_spec.rb
+++ b/spec/readme_spec.rb
@@ -72,7 +72,7 @@ describe 'README' do
         subject {
           if example == :example0
             expect(RDF::Util::File).to receive(:open_file).
-              with("http://ruby-rdf.github.com/rdf/etc/doap.nt", {}).
+              with("http://ruby-rdf.github.com/rdf/etc/doap.nt", hash_including(:headers)).
               at_least(1).
               and_yield(Kernel.open(File.expand_path("../../etc/doap.nt", __FILE__)))
           end
@@ -109,7 +109,7 @@ describe 'README' do
         subject {
           if example == :example0
             expect(RDF::Util::File).to receive(:open_file).
-              with("http://ruby-rdf.github.com/rdf/etc/doap.nq", {:base_uri=>"http://ruby-rdf.github.com/rdf/etc/doap.nq"}).
+              with("http://ruby-rdf.github.com/rdf/etc/doap.nq", hash_including(:headers, base_uri: "http://ruby-rdf.github.com/rdf/etc/doap.nq")).
               at_least(1).
               and_yield(Kernel.open(File.expand_path("../../etc/doap.nq", __FILE__)))
           end

--- a/spec/util_file_spec.rb
+++ b/spec/util_file_spec.rb
@@ -13,6 +13,8 @@ describe RDF::Util::File do
 
     it "returns Net::HTTP if rest-client is not available" do
       hide_const("RestClient")
+      RDF::Util::File.remove_instance_variable(:@http_adapter)
+      RDF::Util::File.http_adapter
       expect(RDF::Util::File.http_adapter).to eq RDF::Util::File::NetHttpAdapter
     end
 

--- a/spec/writer_spec.rb
+++ b/spec/writer_spec.rb
@@ -1,0 +1,20 @@
+# -*- encoding: utf-8 -*-
+require File.join(File.dirname(__FILE__), 'spec_helper')
+require 'rdf/ntriples'
+
+describe RDF::Writer do
+  describe ".for" do
+    [
+      :ntriples,
+      'etc/doap.nt',
+      {file_name:      'etc/doap.nt'},
+      {file_extension: 'nt'},
+      {content_type:   'application/n-triples'},
+      {content_type:   'text/plain'},
+    ].each do |arg|
+      it "discovers with #{arg.inspect}" do
+        expect(RDF::Writer.for(arg)).to eq RDF::NTriples::Writer
+      end
+    end
+  end
+end


### PR DESCRIPTION
These commits update Reader.open to attempt to find a concrete reader before calling `Util::File.open_file` and sets the Accept header narrowly if it can. This fixes a problem when a specific format is selected, but a request is made which ends up returning a different content-type due to content negotiation. This narrows the acceptable content types.

Fixes #347.