### PR TITLE
Allow `RDF::Vocabulary#send` and `#public_send`

### DIFF
--- a/lib/rdf/vocabulary.rb
+++ b/lib/rdf/vocabulary.rb
@@ -448,7 +448,7 @@ module RDF
     undef_method(*instance_methods.
                   map(&:to_s).
                   select {|m| m =~ /^\w+$/}.
-                  reject {|m| %w(object_id dup instance_eval inspect to_s class).include?(m) || m[0,2] == '__'}.
+                  reject {|m| %w(object_id dup instance_eval inspect to_s class send public_send).include?(m) || m[0,2] == '__'}.
                   map(&:to_sym))
 
     ##

--- a/spec/vocabulary_spec.rb
+++ b/spec/vocabulary_spec.rb
@@ -27,6 +27,16 @@ describe RDF::Vocabulary do
       expect(subject["foo"]).to be_a(RDF::Vocabulary::Term)
     end
 
+    it "allows #send" do
+      expect {subject.send(:foo)}.not_to raise_error
+      expect(subject.send(:foo)).to be_a(RDF::Vocabulary::Term)
+    end
+
+    it "allows #public_send" do
+      expect {subject.public_send(:foo)}.not_to raise_error
+      expect(subject.public_send(:foo)).to be_a(RDF::Vocabulary::Term)
+    end
+
     it "does not add to @@uris" do
       RDF::Vocabulary.new("http://example/")
       expect(RDF::Vocabulary.class_variable_get(:"@@uris")).to be_a(Hash)


### PR DESCRIPTION
This reinstates `#send` and `#public_send` as a fix for #356.

We undefine many of the methods on `Vocabulary::Term` objects to clear the way for `#method_missing`; `#send` and other metaprogramming methods like `#instance_methods` are caught up in this. 
`:send` doesn't seem to be a popular vocabulary term, so it's arguably harmless.

The behavior around this is pretty messy; honestly, the whole thing has me thinking about deprecating the method_missing handling and pushing users to `#[]` syntax much aggressively for 3.0.0. But I do think this is an improvement, since `#send` currently works on Vocabularies defined as classes (`class MyVocab < RDF::Vocabulary('...'); end`), and only errors when defining vocabulary instances (as `v = RDF::Vocabulary.new('...')`).