### PR TITLE
Don't attempt to build URIs from Class names

### DIFF
--- a/lib/rdf/vocabulary.rb
+++ b/lib/rdf/vocabulary.rb
@@ -273,7 +273,7 @@ module RDF
       #
       # @return [RDF::URI]
       def to_uri
-        RDF::URI.intern(to_s)
+        RDF::URI.intern(@@uris[self].to_s)
       end
 
       # For IRI compatibility

--- a/spec/vocabulary_spec.rb
+++ b/spec/vocabulary_spec.rb
@@ -357,6 +357,14 @@ describe RDF::Vocabulary do
       end
     end
 
+    context 'without a uri' do
+      let!(:vocab) { @vocab ||= RDF::Vocabulary.from_graph(graph) }
+
+      it "gives a null relative uri" do
+        expect(vocab.to_uri).to eq RDF::URI.new(nil)
+      end
+    end
+
     context "with existing Vocabulary" do
       let!(:nt) {%{
         <http://example/Klass> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .


### PR DESCRIPTION
RDF::Vocabulary would previously attempt to build URIs from Class names when no URI was present for the vocabulary class. We now use a null relative URI instead.

Closes #355.