### PR TITLE
Fix issue when logging multiple invalid statements to $stderr.

### DIFF
--- a/lib/rdf/util/logger.rb
+++ b/lib/rdf/util/logger.rb
@@ -1,5 +1,6 @@
 # coding: utf-8
 require 'logger'
+require 'delegate'
 
 module RDF; module Util
   ##
@@ -18,7 +19,7 @@ module RDF; module Util
       logger = @options[:logger] if logger.nil? && @options
       if logger.nil?
         # Unless otherwise specified, use $stderr
-        logger = (@options || options)[:logger] = $stderr
+        logger = (@options || options)[:logger] = DelegateClass(IO).new($stderr)
 
         # Reset log_statistics so that it's not inherited across different instances
         logger.log_statistics.clear if logger.respond_to?(:log_statistics)

--- a/spec/ntriples_spec.rb
+++ b/spec/ntriples_spec.rb
@@ -852,6 +852,27 @@ describe RDF::NTriples::Writer do
       include_examples "c14n", st, result
     end
   end
+
+  context "logging behavior when dumping invalid statements multiple times in a row" do
+    before do
+      allow($stderr).to receive(:write)
+    end
+
+    it "raises each time an invalid statement is dumped (not only the first time)" do
+      g = RDF::Graph.new
+      g.from_ntriples('<http://rubygems.org/gems/rdf/resource/0cb45b70-4c37-4270-9955-350c636496fc> <http://rubygems.org/gems/rdf/ontology/xxx/1.1#testDate> "2018-06-01T16:30:00Z"^^<http://www.w3.org/2001/XMLSchema#date> .')
+
+      errors = (1..5).map do |_|
+        begin
+          g.dump(:ntriples)
+          'noraise'
+        rescue RDF::WriterError
+          'raise'
+        end
+      end
+      expect(errors).to eq(['raise'] * 5)
+    end
+  end
 end
 
 describe RDF::NTriples do

--- a/spec/util_logger_spec.rb
+++ b/spec/util_logger_spec.rb
@@ -202,7 +202,7 @@ describe RDF::Util::Logger do
     subject {LogTester.new}
 
     it "sets logger to $stderr" do
-      expect(subject.logger).to equal $stderr
+      expect(subject.logger).to eq $stderr
     end
 
     it "forgets log_statistics between instances" do


### PR DESCRIPTION
Hello @gkellogg ,

This PR should fix the issue reported by @abrisse where dumping multiple graphs with invalid statements was raising error only the first time (if logging to the default $stderr). The bug could be reproduced by running the following code in a bundle console:

```ruby
g = RDF::Graph.new
g.from_ntriples(%w[
  <http://rubygems.org/gems/rdf/resource/0cb45b70-4c37-4270-9955-350c636496fc>
  <http://rubygems.org/gems/rdf/ontology/xxx/1.1#testDate>
  "2018-06-01T16:30:00Z"^^<http://www.w3.org/2001/XMLSchema#date>
  .].join(' '))
g.dump(:ntriples) # raises RDF::WriterError as expected the first time
g.dump(:ntriples) # ignores the invalid statements the second time (and does not raise!)
```

The proposed fix is to wrap the default logger output (`$stderr`) in a `DelegateClass` so that the state attributes added by including `RDF::Util::Logger` stay local to the Writer class and are not shared with other Writer classes (since `$stderr` is a global variable).