### PR TITLE
Ntriple reader profiling and performance fixes

### DIFF
--- a/lib/rdf.rb
+++ b/lib/rdf.rb
@@ -4,6 +4,7 @@ require 'date'
 require 'time'
 
 require 'rdf/version'
+require 'rdf/extensions'
 
 module RDF
   # RDF mixins

--- a/lib/rdf/extensions.rb
+++ b/lib/rdf/extensions.rb
@@ -1,0 +1,22 @@
+##
+# This file provides compatibility monkeypatches to standard library classes
+# Implementation taken from MIT-licensed https://github.com/marcandre/backports
+#
+
+# https://github.com/marcandre/backports/blob/master/lib/backports/2.4.0/regexp/match.rb
+unless Regexp.method_defined? :match?
+  class Regexp
+    def match?(*args)
+      !match(*args).nil?
+    end
+  end
+end
+
+# https://github.com/marcandre/backports/blob/master/lib/backports/2.4.0/string/match.rb
+unless String.method_defined? :match?
+  class String
+    def match?(*args)
+      !match(*args).nil?
+    end
+  end
+end

--- a/lib/rdf/ntriples/reader.rb
+++ b/lib/rdf/ntriples/reader.rb
@@ -154,7 +154,7 @@ module RDF::NTriples
       end
     end
 
-    # cache constantes to optimize escaping the escape chars in self.unescape
+    # cache constants to optimize escaping the escape chars in self.unescape
     ESCAPE_CHARS_ESCAPED = ESCAPE_CHARS.each_with_object({}) do |escape, memo|
       memo[escape.inspect[1...-1]] = escape
     end.freeze
@@ -175,9 +175,8 @@ module RDF::NTriples
         string = string.dup.force_encoding(Encoding::UTF_8)
       end
 
-      # note: Ruby 2.4 should use `match?` of `=~` for better performance.
-      has_escape_chars = (string =~ ESCAPE_CHARS_ESCAPED_REGEXP)
-      has_uchar = (string =~ UCHAR)
+      has_escape_chars = ESCAPE_CHARS_ESCAPED_REGEXP.match?(string)
+      has_uchar = UCHAR.match?(string)
 
       string = string.dup if has_escape_chars || has_uchar
 

--- a/lib/rdf/reader.rb
+++ b/lib/rdf/reader.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module RDF
   ##
   # The base class for RDF parsers.
@@ -610,7 +611,8 @@ module RDF
     def readline
       @line = @line_rest || @input.readline
       @line, @line_rest = @line.split("\r", 2)
-      @line = @line.to_s.chomp
+      @line = String.new if @line.nil? # not frozen
+      @line.chomp!
       begin
         @line.encode!(encoding)
       rescue Encoding::UndefinedConversionError, Encoding::InvalidByteSequenceError, Encoding::ConverterNotFoundError


### PR DESCRIPTION
Hello @gkellogg ,

I spent some time profiling the ntriple reader to reduce object allocations and boost performance.
This PR contains my first improvements after this profiling (I may add more commits later).

I profiled using the following script (after adding`gem 'stackprof'` to the Gemfile):
```ruby
#!/usr/bin/ruby

require 'stackprof'

require 'rdf'
require 'rdf/ntriples'

def processing(_i)
  RDF::Graph.load('statements.nt')
end

# speed
require "benchmark"
Benchmark.bmbm do |bm|
  bm.report('current code') do
    (1..500).each do |i|
      processing(i)
    end
  end
end

# stackprof
memo = {}
#StackProf.run(mode: :cpu, out: 'tmp/stackprof-myapp.dump', interval: 1000) do
StackProf.run(mode: :object, out: 'tmp/stackprof-myapp.dump', interval: 1) do
  (1..500).each do |i|
    memo[i] = processing(i)
  end
end
memo
```
After running the script, I ran `bundle exec stackprof tmp/stackprof-myapp.dump --text --limit 10` to display the total object count.

The results are as follow:
 - branch develop (base branch for this PR): 500 loadings of "statements.nt" took 2.86 seconds and instantiated 4.35 million objects
 - with this PR the same 500 loadings took 1.85 seconds and instantiated 2.77 million objects (27% less objects)
Note : the "statements.nt" file used in the benchmark contains 64 triples, each lines having around 250 characters.

I pushed one commit for each separate improvements. The major one was to eliminate most unneeded object allocations in `RDF::Ntriples::Reader.unescape` ; smaller (but still interesting) improvements were done in `RDF::Reader#readline` by using frozen literals (because of the `@line.split("\r", 2)`) and avoiding copying the full @line to chomp it.

The specs still pass unchanged.

Feel free to give feedback on the individual commits of this PR if you have question on some of my choices. 