### PR TITLE
Regexp match refactor

### DIFF
--- a/lib/rdf.rb
+++ b/lib/rdf.rb
@@ -228,7 +228,7 @@ module RDF
   def self.method_missing(property, *args, &block)
     if args.empty?
       # Special-case rdf:_n for all integers
-      RDF_N_REGEXP.match(property) ? RDF::URI("#{to_uri}#{property}") : RDF::RDFV.send(property)
+      RDF_N_REGEXP.match?(property) ? RDF::URI("#{to_uri}#{property}") : RDF::RDFV.send(property)
     else
       super
     end

--- a/lib/rdf.rb
+++ b/lib/rdf.rb
@@ -198,7 +198,7 @@ module RDF
   # @return [#to_s] property
   # @return [URI]
   def self.[](property)
-    property.to_s =~ %r{_\d+} ? RDF::URI("#{to_uri}#{property}") : RDF::RDFV[property]
+    property.to_s.match?(%r{_\d+}) ? RDF::URI("#{to_uri}#{property}") : RDF::RDFV[property]
   end
 
   ##

--- a/lib/rdf/model/literal.rb
+++ b/lib/rdf/model/literal.rb
@@ -363,7 +363,7 @@ module RDF
       return false if language? && language.to_s !~ /^[a-zA-Z]+(-[a-zA-Z0-9]+)*$/
       return false if datatype? && datatype.invalid?
       grammar = self.class.const_get(:GRAMMAR) rescue nil
-      grammar.nil? || !!(value =~ grammar)
+      grammar.nil? || value.match?(grammar)
     end
 
     ##

--- a/lib/rdf/model/uri.rb
+++ b/lib/rdf/model/uri.rb
@@ -1006,7 +1006,7 @@ module RDF
     def path=(value)
       if value
         # Always lead with a slash
-        value = "/#{value}" if host && value.to_s =~ /^[^\/]/
+        value = "/#{value}" if host && value.to_s.match?(/^[^\/]/)
         object[:path] = value.to_s.force_encoding(Encoding::UTF_8)
       else
         object[:path] = nil

--- a/lib/rdf/nquads.rb
+++ b/lib/rdf/nquads.rb
@@ -36,7 +36,7 @@ module RDF
       # @param [String] sample Beginning several bytes (about 1K) of input.
       # @return [Boolean]
       def self.detect(sample)
-        !!sample.match(%r(
+        sample.match?(%r(
           (?:\s*(?:<[^>]*>) | (?:_:\w+))                          # Subject
           \s*
           (?:\s*<[^>]*>)                                          # Predicate
@@ -46,8 +46,8 @@ module RDF
           (?:\s*(?:<[^>]*>) | (?:_:\w+))                          # Graph Name
           \s*\.
         )x) && !(
-          sample.match(%r(@(base|prefix|keywords)|\{)) ||         # Not Turtle/N3/TriG
-          sample.match(%r(<(html|rdf))i)                          # Not HTML or XML
+          sample.match?(%r(@(base|prefix|keywords)|\{)) ||         # Not Turtle/N3/TriG
+          sample.match?(%r(<(html|rdf))i)                          # Not HTML or XML
         )
       end
 

--- a/lib/rdf/ntriples/format.rb
+++ b/lib/rdf/ntriples/format.rb
@@ -32,7 +32,7 @@ module RDF::NTriples
     # @param [String] sample Beginning several bytes (about 1K) of input.
     # @return [Boolean]
     def self.detect(sample)
-      !!sample.match(%r(
+      sample.match?(%r(
         (?:(?:<[^>]*>) | (?:_:\w+))                             # Subject
         \s*
         (?:<[^>]*>)                                             # Predicate
@@ -40,8 +40,8 @@ module RDF::NTriples
         (?:(?:<[^>]*>) | (?:_:\w+) | (?:"[^"\n]*"(?:^^|@\S+)?)) # Object
         \s*\.
       )x) && !(
-        sample.match(%r(@(base|prefix|keywords)|\{)) ||         # Not Turtle/N3/TriG
-        sample.match(%r(<(html|rdf))i)                          # Not HTML or XML
+        sample.match?(%r(@(base|prefix|keywords)|\{)) ||         # Not Turtle/N3/TriG
+        sample.match?(%r(<(html|rdf))i)                          # Not HTML or XML
       ) && !RDF::NQuads::Format.detect(sample)
     end
 

--- a/lib/rdf/ntriples/writer.rb
+++ b/lib/rdf/ntriples/writer.rb
@@ -56,7 +56,7 @@ module RDF::NTriples
     # @see    http://www.w3.org/TR/rdf-testcases/#ntrip_strings
     def self.escape(string, encoding = nil)
       ret = case
-        when string =~ ESCAPE_PLAIN # a shortcut for the simple case
+        when string.match?(ESCAPE_PLAIN) # a shortcut for the simple case
           string
         when string.ascii_only?
           StringIO.open do |buffer|
@@ -256,7 +256,7 @@ module RDF::NTriples
     def format_uri(uri, **options)
       string = uri.to_s
       iriref = case
-        when string =~ ESCAPE_PLAIN_U # a shortcut for the simple case
+        when string.match?(ESCAPE_PLAIN_U) # a shortcut for the simple case
           string
         when string.ascii_only? || (encoding && encoding != Encoding::ASCII)
           StringIO.open do |buffer|

--- a/lib/rdf/query/solution.rb
+++ b/lib/rdf/query/solution.rb
@@ -24,7 +24,7 @@ class RDF::Query
     # Undefine all superfluous instance methods:
     undef_method(*instance_methods.
                   map(&:to_s).
-                  select {|m| m =~ /^\w+$/}.
+                  select {|m| m.match?(/^\w+$/)}.
                   reject {|m| %w(object_id dup instance_eval inspect to_s private_methods class should should_not pretty_print).include?(m) || m[0,2] == '__'}.
                   map(&:to_sym))
 

--- a/lib/rdf/util/file.rb
+++ b/lib/rdf/util/file.rb
@@ -290,7 +290,7 @@ module RDF; module Util
       filename_or_url = $1 if filename_or_url.to_s.match(/^file:(.*)$/)
       remote_document = nil
 
-      if filename_or_url.to_s =~ /^https?/
+      if filename_or_url.to_s.match?(/^https?/)
         base_uri = filename_or_url.to_s
 
         remote_document = self.http_adapter(!!options[:use_net_http]).

--- a/lib/rdf/vocabulary.rb
+++ b/lib/rdf/vocabulary.rb
@@ -892,7 +892,7 @@ module RDF
       # @since 0.3.9
       def valid?
         # Validate relative to RFC3987
-        node? || RDF::URI::IRI.match(to_s) || false
+        node? || RDF::URI::IRI.match?(to_s) || false
       end
 
       ##

--- a/lib/rdf/vocabulary.rb
+++ b/lib/rdf/vocabulary.rb
@@ -620,7 +620,7 @@ module RDF
     # Undefine all superfluous instance methods:
     undef_method(*instance_methods.
                   map(&:to_s).
-                  select {|m| m =~ /^\w+$/}.
+                  select {|m| m.match?(/^\w+$/)}.
                   reject {|m| %w(object_id dup instance_eval inspect to_s class send public_send).include?(m) || m[0,2] == '__'}.
                   map(&:to_sym))
 
@@ -927,7 +927,7 @@ module RDF
       # Is this neither a class, property or datatype term?
       # @return [Boolean]
       def other?
-        Array(self.type).none? {|t| t.to_s =~ /(Class|Property|Datatype|Restriction)/}
+        Array(self.type).none? {|t| t.to_s.match?(/(Class|Property|Datatype|Restriction)/)}
       end
 
       ##


### PR DESCRIPTION
Hello @gkellogg , as promised in https://github.com/ruby-rdf/rdf/pull/382#issuecomment-422744261 , here is a PR to replace all usages of `=~` and `.match` in the rdf code base with `.match?` (only when last match results are not used). I did not benchmark but it should result in improvements when running over Ruby 2.4 and higher.