### PR TITLE
"Fix" syntax in vocabulary.rb that Ruby versions < 2.2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
 env:
   - CI=true
 rvm:
-  - 2.2
+  - 2.2.2
   - 2.3
   - 2.4
   - 2.5

--- a/lib/rdf/vocabulary.rb
+++ b/lib/rdf/vocabulary.rb
@@ -534,7 +534,7 @@ module RDF
         term_defs.each do |term, attributes|
           # Turn embedded BNodes into either their Term definition or a List
           attributes.each do |ak, avs|
-            attributes[ak] = avs.is_a?(Array) ? avs.map do |av|
+            attributes[ak] = avs.is_a?(Array) ? (avs.map do |av|
               l = RDF::List.new(subject: av, graph: graph)
               if l.valid?
                 RDF::List.new(subject: av) do |nl|
@@ -547,7 +547,7 @@ module RDF
               else
                 av
               end
-            end.compact : avs
+            end).compact : avs
           end
 
           if term == :""


### PR DESCRIPTION
 don't parse properly. Set Travis to test on 2.2.2, not just 2.2, which defaulted to 2.2.7 at the time of this fix.

Fixes #386.