### PR TITLE
Implement marshaling methods to avoid issue with serializing mutex

### DIFF
--- a/lib/rdf/model/uri.rb
+++ b/lib/rdf/model/uri.rb
@@ -1263,6 +1263,26 @@ module RDF
       return res
     end
 
+    ##
+    # Dump of data needed to reconsitute this object using Marshal.load
+    # This override is needed to avoid serializing @mutex.
+    #
+    # @param [Integer] level The maximum depth of objects to dump.
+    # @return [String] The dump of data needed to reconsitute this object.
+    def _dump(level)
+      value
+    end
+
+    ##
+    # Load dumped data to reconsitute marshaled object
+    # This override is needed to avoid serializing @mutex.
+    #
+    # @param [String] data The dump of data needed to reconsitute this object.
+    # @return [RDF::URI] The reconsituted object.
+    def self._load(data)
+      new(data)
+    end
+
   private
 
     ##

--- a/spec/model_uri_spec.rb
+++ b/spec/model_uri_spec.rb
@@ -983,4 +983,17 @@ describe RDF::URI do
       end
     end
   end
+
+  describe 'marshaling' do
+    subject { RDF::URI("http://example/") }
+
+    it "marshals them" do
+      marshaled = Marshal.dump(subject)
+      loaded    = Marshal.load(marshaled)
+
+      expect(loaded).to eq subject
+      # It should have a mutex
+      expect { loaded.freeze }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
The default marshal dump method attempts to serialize RDF::URI's mutex which leads to an error: `TypeError: no _dump_data is defined for class Thread::Mutex`.  This PR implements the `_dump` and `_load` methods (https://ruby-doc.org/core-2.5.0/Marshal.html#module-Marshal-label-_dump+and+_load) to avoid this error.

Related https://github.com/samvera/active_fedora/issues/1378.