### PR TITLE
A Time should be typed as XMLSchema#dateTime

### DIFF
--- a/lib/rdf/model/literal.rb
+++ b/lib/rdf/model/literal.rb
@@ -119,8 +119,8 @@ module RDF
           when ::Float      then RDF::Literal::Double
           when ::BigDecimal then RDF::Literal::Decimal
           when ::DateTime   then RDF::Literal::DateTime
+          when ::Time       then RDF::Literal::DateTime
           when ::Date       then RDF::Literal::Date
-          when ::Time       then RDF::Literal::Time # FIXME: Ruby's Time class can represent datetimes as well
           when ::Symbol     then RDF::Literal::Token
           else self
         end

--- a/spec/model_literal_spec.rb
+++ b/spec/model_literal_spec.rb
@@ -138,7 +138,7 @@ describe RDF::Literal do
       3.1415 => "double",
       Date.new(2010) => "date",
       DateTime.new(2011) => "dateTime",
-      Time.parse("01:02:03Z") => "time"
+      Time.parse("01:02:03Z") => "dateTime"
     }.each_pair do |value, type|
       it "returns xsd.#{type} for #{value.inspect} #{value.class}" do
         expect(RDF::Literal.new(value).datatype).to eq XSD[type]
@@ -217,7 +217,7 @@ describe RDF::Literal do
       literal(:double)   => "3.1415",
       literal(:date)     => "2010-01-01",
       literal(:datetime) => "2011-01-01T00:00:00Z",
-      literal(:time)     => "01:02:03Z"
+      literal(:time)     => "#{Date.today}T01:02:03Z"
     }.each_pair do |args, rep|
       it "returns #{rep} for #{args.inspect}" do
         literal = RDF::Literal.new(*args)


### PR DESCRIPTION
Ruby does not have a class which represents a time without date. A Tod::TimeOfDay provided by the `tod` gem would justify  XMLSchema#time, but the default Time class always includes a Date.