### PR TITLE
Correct label on xsd:boolean

### DIFF
--- a/etc/xsd.ttl
+++ b/etc/xsd.ttl
@@ -55,7 +55,7 @@ xsd:base64Binary a rdfs:Datatype;
 
 xsd:boolean a rdfs:Datatype;
   rdfs:subClassOf xsd:anyAtomicType;
-  rdfs:label "base64Binary";
+  rdfs:label "boolean";
   rdfs:comment """
     boolean represents the values of two-valued logic.
   """ .


### PR DESCRIPTION
There seems to be a copy and paste error with the label of the boolean.