### PR TITLE
Closes #403

### DIFF
--- a/lib/rdf/changeset.rb
+++ b/lib/rdf/changeset.rb
@@ -159,7 +159,7 @@ module RDF
     # This simply returns its argument as an array in order to trick
     # {RDF::Mutable#delete} into working.
     def query stmt
-      [stmt]
+      RDF::Query.new RDF::Query::Pattern.from(stmt)
     end
 
     undef_method :load, :update, :clear

--- a/lib/rdf/changeset.rb
+++ b/lib/rdf/changeset.rb
@@ -156,6 +156,12 @@ module RDF
       self.deletes << statement
     end
 
+    # This simply returns its argument as an array in order to trick
+    # {RDF::Mutable#delete} into working.
+    def query stmt
+      [stmt]
+    end
+
     undef_method :load, :update, :clear
   end # Changeset
 end # RDF

--- a/lib/rdf/changeset.rb
+++ b/lib/rdf/changeset.rb
@@ -156,7 +156,7 @@ module RDF
       self.deletes << statement
     end
 
-    # This simply returns its argument as an array in order to trick
+    # This simply returns its argument as a query in order to trick
     # {RDF::Mutable#delete} into working.
     def query stmt
       RDF::Query.new RDF::Query::Pattern.from(stmt)

--- a/lib/rdf/changeset.rb
+++ b/lib/rdf/changeset.rb
@@ -158,7 +158,7 @@ module RDF
 
     # This simply returns its argument as a query in order to trick
     # {RDF::Mutable#delete} into working.
-    def query stmt
+    def query(stmt)
       RDF::Query.new RDF::Query::Pattern.from(stmt)
     end
 

--- a/lib/rdf/repository.rb
+++ b/lib/rdf/repository.rb
@@ -340,7 +340,14 @@ module RDF
       # @see Mutable#apply_changeset
       def apply_changeset(changeset)
         data = @data
-        changeset.deletes.each { |del| data = delete_from(data, del) }
+        changeset.deletes.each do |del|
+          if del.constant?
+            data = delete_from(data, del)
+          else
+            # we need this condition to handle wildcard statements
+            query_pattern(del) { |stmt| data = delete_from(data, stmt) }
+          end
+        end
         changeset.inserts.each { |ins| data = insert_to(data, ins) }
         @data = data
       end

--- a/spec/changeset_spec.rb
+++ b/spec/changeset_spec.rb
@@ -73,6 +73,14 @@ describe RDF::Changeset do
         expect { subject.apply(repo) }
           .to change { repo.statements }.to contain_exactly(new_statement)
       end
+
+      it "correctly applies a wildcard/pattern" do
+        repo << st
+
+        subject.delete RDF::Statement(nil, RDF::URI('p'), nil)
+
+        expect { subject.apply(repo) }.to change { repo.statements }.to be_empty
+      end
     end
   end
 


### PR DESCRIPTION
This patch contains both the missing `query` method for `RDF::Changeset` (which I made protected) , as well as ameliorated behaviour on the part of `RDF::Repository`.

I had originally had the `query` method return just an array as that's all `RDF::Mutable#delete` needs to proceed, but then changed it to return an `RDF::Query` with the partial statement as a single pattern. The other solution would be for `RDF::Changeset` to just go around `RDF::Mutable#delete`.

The separate branch [test-wildcard-changeset contains a test case](https://github.com/doriantaylor/rdf/blob/test-wildcard-changeset/spec/changeset_spec.rb#L77) that will demonstrate the crash scenario. You are right however that without its own modifications, `RDF::Repository` would not correctly apply the partial statement, so in effect this one test case probes both scenarios. I don't know if you want a separate/duplicate test case for that.