### PR TITLE
RDF::Changeset is now free of RDF::Mutable/RDF::Writable (Closes #405)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ Gemfile.lock
 benchmark/
 /.byebug_history
 /coverage/
+\#*\#
+.\#*

--- a/lib/rdf/changeset.rb
+++ b/lib/rdf/changeset.rb
@@ -99,10 +99,20 @@ module RDF
       false
     end
 
+    ##
+    # Returns +false+ to indicate that this changeset _itself_ is not writable.
+    #
+    # @return [Boolean]
+    # @see    RDF::Writable#writable?
     def writable?
       false
     end
 
+    ##
+    # Returns +false+ to indicate that this changeset _itself_ is not mutable.
+    #
+    # @return [Boolean]
+    # @see    RDF::Mutable#mutable?
     def mutable?
       false
     end

--- a/lib/rdf/changeset.rb
+++ b/lib/rdf/changeset.rb
@@ -87,9 +87,9 @@ module RDF
     end
 
     ##
-    # Returns +false+ to indicate that this changeset is append-only.
+    # Returns `false` to indicate that this changeset is append-only.
     #
-    # Changesets do not support the +RDF::Enumerable+ protocol directly.
+    # Changesets do not support the `RDF::Enumerable` protocol directly.
     # To enumerate the RDF statements to be inserted or deleted, use the
     # {RDF::Changeset#inserts} and {RDF::Changeset#deletes} accessors.
     #
@@ -100,7 +100,7 @@ module RDF
     end
 
     ##
-    # Returns +false+ to indicate that this changeset _itself_ is not writable.
+    # Returns `false` as changesets are not {RDF::Writable}.
     #
     # @return [Boolean]
     # @see    RDF::Writable#writable?
@@ -109,7 +109,7 @@ module RDF
     end
 
     ##
-    # Returns +false+ to indicate that this changeset _itself_ is not mutable.
+    # Returns `false` as changesets are not {RDF::Mutable}.
     #
     # @return [Boolean]
     # @see    RDF::Mutable#mutable?
@@ -130,7 +130,7 @@ module RDF
     end
 
     ##
-    # @return [Boolean] +true+ iff inserts and deletes are both empty
+    # @return [Boolean] `true` iff inserts and deletes are both empty
     def empty?
       deletes.empty? && inserts.empty?
     end
@@ -146,7 +146,7 @@ module RDF
 
     ##
     # Outputs a developer-friendly representation of this changeset to
-    # +$stderr+.
+    # `$stderr`.
     #
     # @return [void]
     def inspect!
@@ -154,21 +154,21 @@ module RDF
     end
 
     ##
-    # Returns the sum of both the +inserts+ and +deletes+ counts.
+    # Returns the sum of both the `inserts` and `deletes` counts.
     #
     # @return [Integer]
     def count
       inserts.count + deletes.count
     end
 
-    # Append statements to +inserts+. Statements _should_ be constant
+    # Append statements to `inserts`. Statements _should_ be constant
     # as variable statements will at best be ignored or at worst raise
     # an error when applied.
     #
-    # @param statements [Enumerable, # RDF::Statement] Some statements
+    # @param statements [Enumerable, RDF::Statement] Some statements
     # @return [self]
     def insert(*statements)
-      process_statements(statements) do |stmts|
+      coerce_statements(statements) do |stmts|
         append_statements :inserts, stmts
       end
 
@@ -177,14 +177,14 @@ module RDF
     alias_method :insert!, :insert
     alias_method :<<, :insert
 
-    # Append statements to +deletes+. Statements _may_ contain
+    # Append statements to `deletes`. Statements _may_ contain
     # variables, although support will depend on the {RDF::Mutable}
     # target.
     #
     # @param statements [Enumerable, RDF::Statement] Some statements
     # @return [self]
     def delete(*statements)
-      process_statements(statements) do |stmts|
+      coerce_statements(statements) do |stmts|
         append_statements :deletes, stmts
       end
 
@@ -196,8 +196,8 @@ module RDF
     private
 
     ##
-    # Append statements to the appropriate target. This is a crappy
-    # little shim to go in between the other shim and the target.
+    # Append statements to the appropriate target. This is a little
+    # shim to go in between the other shim and the target.
     #
     # @param target [Symbol] the method to send
     # @param arg [Enumerable, RDF::Statement]

--- a/lib/rdf/mixin/mutable.rb
+++ b/lib/rdf/mixin/mutable.rb
@@ -154,20 +154,9 @@ module RDF
     def delete(*statements)
       raise TypeError.new("#{self} is immutable") if immutable?
 
-      statements.map! do |value|
-        case
-          when value.respond_to?(:each_statement)
-            delete_statements(value)
-            nil
-          when (statement = Statement.from(value)).constant?
-            statement
-          else
-            delete_statements(query(value))
-            nil
-        end
+      process_statements(statements, query: true, constant: true) do |value|
+        delete_statements(value)
       end
-      statements.compact!
-      delete_statements(statements) unless statements.empty?
 
       return self
     end

--- a/lib/rdf/mixin/mutable.rb
+++ b/lib/rdf/mixin/mutable.rb
@@ -155,7 +155,7 @@ module RDF
     def delete(*statements)
       raise TypeError.new("#{self} is immutable") if immutable?
 
-      process_statements(statements, query: true, constant: true) do |value|
+      coerce_statements(statements, query: true, constant: true) do |value|
         delete_statements(value)
       end
 

--- a/lib/rdf/mixin/mutable.rb
+++ b/lib/rdf/mixin/mutable.rb
@@ -9,6 +9,7 @@ module RDF
     extend  RDF::Util::Aliasing::LateBound
     include RDF::Readable
     include RDF::Writable
+    include RDF::Util::Coercions
 
     ##
     # Returns `true` if `self` is mutable.

--- a/lib/rdf/mixin/writable.rb
+++ b/lib/rdf/mixin/writable.rb
@@ -7,6 +7,7 @@ module RDF
   # @see RDF::Repository
   module Writable
     extend RDF::Util::Aliasing::LateBound
+    include RDF::Util::Coercions
 
     ##
     # Returns `true` if `self` is writable.
@@ -58,53 +59,13 @@ module RDF
     #   @param  [Enumerable<RDF::Statement>] statements
     #   @return [self]
     def insert(*statements)
-      process_statements(statements) { |value| insert_statements(value) }
+      process_statements(statements) { |value| insert_statements value }
 
       return self
     end
     alias_method :insert!, :insert
 
   protected
-
-  ##
-  # Coerce a set of arguments into {RDF::Statement} objects and then
-  # operate over them with a block.
-  # 
-  # @example
-  #  process_statements(statements) { |value| do_something(value) }
-  #
-  # @param statements [#map] The arbitrary-ish input to be manipulated
-  # @param query [false, true] Whether to call +query+ before the block
-  # @param constant [false, true] Whether to test if the statements
-  #  are constant
-  # @yield [RDF::Statement, RDF::Enumerable] 
-  # @return statements
-  def process_statements(statements, query: false, constant: false, &block)
-    raise ArgumentError, 'expecting a block' unless block_given?
-
-    statements = statements.map do |value|
-      case
-      when value.respond_to?(:each_statement)
-        block.call(value)
-        nil
-      when (statement = Statement.from(value)) &&
-          (!constant || statement.constant?)
-        statement
-      when query
-        block.call(query(value))
-        nil
-      else
-        raise ArgumentError, "Not a valid statement: #{value.inspect}"
-      end
-    end.compact
-
-    block.call(statements) unless statements.empty?
-
-    # eh might as well return these
-    statements
-  end
-
-
     ##
     # Inserts statements from the given RDF reader into the underlying
     # storage or output stream.

--- a/lib/rdf/mixin/writable.rb
+++ b/lib/rdf/mixin/writable.rb
@@ -59,7 +59,7 @@ module RDF
     #   @param  [Enumerable<RDF::Statement>] statements
     #   @return [self]
     def insert(*statements)
-      process_statements(statements) { |value| insert_statements value }
+      coerce_statements(statements) { |value| insert_statements value }
 
       return self
     end

--- a/lib/rdf/util.rb
+++ b/lib/rdf/util.rb
@@ -1,7 +1,8 @@
 module RDF; module Util
-  autoload :Aliasing, 'rdf/util/aliasing'
-  autoload :Cache,    'rdf/util/cache'
-  autoload :File,     'rdf/util/file'
-  autoload :Logger,   'rdf/util/logger'
-  autoload :UUID,     'rdf/util/uuid'
+  autoload :Aliasing,  'rdf/util/aliasing'
+  autoload :Cache,     'rdf/util/cache'
+  autoload :File,      'rdf/util/file'
+  autoload :Logger,    'rdf/util/logger'
+  autoload :UUID,      'rdf/util/uuid'
+  autoload :Coercions, 'rdf/util/coercions'
 end; end

--- a/lib/rdf/util/coercions.rb
+++ b/lib/rdf/util/coercions.rb
@@ -1,0 +1,52 @@
+module RDF
+  module Util
+    module Coercions
+      # This is a provisional module intended to house input
+      # coercions. Currently the only coercion is a statement
+      # preprocessor that is used in e.g. {RDF::Writable#insert} and
+      # {RDF::Mutable#delete}.
+
+      ##
+      # Coerce a set of arguments into {RDF::Statement} objects and then
+      # operate over them with a block.
+      # 
+      # @example
+      #  process_statements(statements) { |value| do_something(value) }
+      #
+      # @param statements [#map] The arbitrary-ish input to be manipulated
+      # @param query [false, true] Whether to call +query+ before the block
+      # @param constant [false, true] Whether to test if the statements
+      #  are constant
+      # @yield [RDF::Statement, RDF::Enumerable] 
+      # @return statements
+      def process_statements(statements, query: false, constant: false, &block)
+        raise ArgumentError, 'expecting a block' unless block_given?
+
+        statements = statements.map do |value|
+          case
+          when value.respond_to?(:each_statement)
+            block.call(value)
+            nil
+          when (statement = Statement.from(value)) &&
+              (!constant || statement.constant?)
+            statement
+          when query
+            # XXX note that this only makes sense when the module is include()d
+            block.call(query(value))
+            nil
+          else
+            raise ArgumentError, "Not a valid statement: #{value.inspect}"
+          end
+        end.compact
+
+        block.call(statements) unless statements.empty?
+
+        # eh might as well return these
+        statements
+      end
+
+      # so you can include or call
+      extend self
+    end
+  end
+end

--- a/lib/rdf/util/coercions.rb
+++ b/lib/rdf/util/coercions.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 module RDF
   module Util
     module Coercions
@@ -6,20 +7,29 @@ module RDF
       # preprocessor that is used in e.g. {RDF::Writable#insert} and
       # {RDF::Mutable#delete}.
 
+      protected
+
       ##
-      # Coerce a set of arguments into {RDF::Statement} objects and then
-      # operate over them with a block.
+      # Coerce an array of arguments into {RDF::Statement}, or
+      # {RDF::Enumerable} and then yield to a block. Note that this
+      # code was amalgamated from that which was sandwiched around
+      # both {RDF::Writable#insert_statements} and
+      # {RDF::Mutable#delete_statements}. The parameters `query` and
+      # `constant` are therefore present to handle the conditions
+      # where the statements contain wildcards and what to do about
+      # them.
       # 
       # @example
-      #  process_statements(statements) { |value| do_something(value) }
+      #  coerce_statements(statements) { |value| do_something(value) }
       #
       # @param statements [#map] The arbitrary-ish input to be manipulated
-      # @param query [false, true] Whether to call +query+ before the block
+      # @param query [false, true] Whether to call `query` before the block
+      #  (as expected by {Mutable#delete_statements})
       # @param constant [false, true] Whether to test if the statements
-      #  are constant
+      #  are constant (as expected by {Mutable#delete_statements})
       # @yield [RDF::Statement, RDF::Enumerable] 
       # @return statements
-      def process_statements(statements, query: false, constant: false, &block)
+      def coerce_statements(statements, query: false, constant: false, &block)
         raise ArgumentError, 'expecting a block' unless block_given?
 
         statements = statements.map do |value|
@@ -32,7 +42,7 @@ module RDF
             statement
           when query
             # XXX note that this only makes sense when the module is include()d
-            block.call(query(value))
+            block.call(self.query(value))
             nil
           else
             raise ArgumentError, "Not a valid statement: #{value.inspect}"
@@ -45,8 +55,6 @@ module RDF
         statements
       end
 
-      # so you can include or call
-      extend self
     end
   end
 end

--- a/spec/changeset_spec.rb
+++ b/spec/changeset_spec.rb
@@ -28,7 +28,7 @@ describe RDF::Changeset do
   its(:deletes) { is_expected.to be_a(RDF::Enumerable) }
   its(:inserts) { is_expected.to be_a(RDF::Enumerable) }
 
-  it { is_expected.to be_mutable }
+  it { is_expected.to_not be_mutable }
   it { is_expected.to_not be_readable }
 
   it "does not respond to #load" do
@@ -135,4 +135,5 @@ describe RDF::Changeset do
         .to change { subject.inserts }.to contain_exactly(*statements)
     end
   end
+
 end


### PR DESCRIPTION
I didn't bother with a test for the coercion cause it gets tested implicitly in `Writable` and `Mutable`. Closes #405.