### PR TITLE
Fix the graph passed to new terms

### DIFF
--- a/lib/rdf/vocabulary.rb
+++ b/lib/rdf/vocabulary.rb
@@ -731,7 +731,7 @@ module RDF
     # @param  [#to_s] property
     # @return [URI]
     def [](property)
-      Term.intern([to_s, property.to_s].join(''), vocab: self.class, attributes: {})
+      Term.intern([to_s, property.to_s].join(''), vocab: self, attributes: {})
     end
 
     ##

--- a/spec/vocabulary_spec.rb
+++ b/spec/vocabulary_spec.rb
@@ -16,26 +16,31 @@ describe RDF::Vocabulary do
     it "should allow method_missing" do
       expect {subject.foo}.not_to raise_error
       expect(subject.foo).to be_a(RDF::Vocabulary::Term)
+      expect(subject.foo.vocab.to_s).to eq('http://example.org/')
     end
 
     it "camelizes on method_missing" do
       expect(subject.foo_bar).to be_a(RDF::Vocabulary::Term)
       expect(subject.foo_bar).to eq (subject.to_uri / 'fooBar')
+      expect(subject.foo_bar.vocab.to_s).to eq('http://example.org/')
     end
 
     it "should allow []" do
       expect {subject["foo"]}.not_to raise_error
       expect(subject["foo"]).to be_a(RDF::Vocabulary::Term)
+      expect(subject["foo"].vocab.to_s).to eq('http://example.org/')
     end
 
     it "allows #send" do
       expect {subject.send(:foo)}.not_to raise_error
       expect(subject.send(:foo)).to be_a(RDF::Vocabulary::Term)
+      expect(subject.send(:foo).vocab.to_s).to eq('http://example.org/')
     end
 
     it "allows #public_send" do
       expect {subject.public_send(:foo)}.not_to raise_error
       expect(subject.public_send(:foo)).to be_a(RDF::Vocabulary::Term)
+      expect(subject.public_send(:foo).vocab.to_s).to eq('http://example.org/')
     end
 
     it "does not add to @@uris" do


### PR DESCRIPTION
It always passed the RDF::Vocabulary class instead of the actual vocab