### PR TITLE
reinstate RDF::Repository::Implementation::SerializedTransaction

### DIFF
--- a/lib/rdf/repository.rb
+++ b/lib/rdf/repository.rb
@@ -244,6 +244,10 @@ module RDF
     # @see RDF::Repository
     module Implementation
       DEFAULT_GRAPH = false
+      
+      ##
+      # @deprecated moved to {RDF::Transaction::SerializedTransaction}
+      SerializedTransaction = RDF::Transaction::SerializedTransaction
 
       ##
       # @private


### PR DESCRIPTION
readds compatiblity for public name
RDF::Repository::Implementation::SerializedTransaction.

with the release of 3.2.0/3.2.1, downstream applications see failing builds due
to the removal of this name. at first glance, it appears that readding the name
reinstates compatibility.

related to #429 