### PR TITLE
Update #start_with? to match String#start_with signature

### DIFF
--- a/lib/rdf/model/value.rb
+++ b/lib/rdf/model/value.rb
@@ -197,19 +197,20 @@ module RDF
     alias_method :validate, :validate!
 
     ##
-    # Returns `true` if this Value starts with the given `string`.
+    # Returns `true` if this Value starts with any of the given strings.
     #
     # @example
     #   RDF::URI('http://example.org/').start_with?('http')     #=> true
     #   RDF::Node('_:foo').start_with?('_:bar')                 #=> false
     #   RDF::Litera('Apple').start_with?('Orange')              #=> false
+    #   RDF::Litera('Apple').start_with?('Orange', 'Apple')     #=> true
     #
-    # @param  [String, #to_s] string
+    # @param  [Array<#to_s>] *args Any number of strings to check against.
     # @return [Boolean] `true` or `false`
     # @see    String#start_with?
     # @since  0.3.0
-    def start_with?(string)
-      to_s.start_with?(string.to_s)
+    def start_with?(*args)
+      to_s.start_with?(*args.map(&:to_s))
     end
     alias_method :starts_with?, :start_with?
 

--- a/spec/model_literal_spec.rb
+++ b/spec/model_literal_spec.rb
@@ -195,6 +195,7 @@ describe RDF::Literal do
   it "#start_with?" do
     expect(RDF::Literal('foo')).to be_start_with('foo')
     expect(RDF::Literal('bar')).not_to be_start_with('foo')
+    expect(RDF::Literal('foo')).to be_start_with('foo', 'nope')
   end
 
   describe "#==" do


### PR DESCRIPTION
Faraday recently started expecting a string-like #start_with? signature, where you can pass multiple strings to test against and it returns true if any of them passes. We were passing an RDF Value to Faraday since the API was mostly consistent.

It seems like the intent is to have the same API as String#start_with?, so this replicates it.