### PR TITLE
Add ostruct to dependencies in preparation of Ruby 3.5.0

### DIFF
--- a/rdf.gemspec
+++ b/rdf.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency     'link_header', '~> 0.0', '>= 0.0.8'
   gem.add_runtime_dependency     'bcp47_spec',  '~> 0.2'
   gem.add_runtime_dependency     'bigdecimal',  '~> 3.1', '>= 3.1.5'
+  gem.add_runtime_dependency     'ostruct',     '~> 0.6'
   gem.add_development_dependency 'base64',      '~> 0.2'
   gem.add_development_dependency 'rdf-spec',    '~> 3.3'
   gem.add_development_dependency 'rdf-turtle',  '~> 3.3'


### PR DESCRIPTION
After upgrading a project to Ruby version 3.3.5, we see the following warnings:

> /Users/mjones/.rvm/gems/ruby-3.3.5@redacted-project-name/gems/rdf-3.3.2/lib/rdf.rb:5: warning: /Users/mjones/.rvm/rubies/ruby-3.3.5/lib/ruby/3.3.0/ostruct.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
Also please contact the author of rdf-3.3.2 to request adding ostruct into its gemspec.

This PR adds the `ostruct` library to the gemspec as suggested, which removes the warning when using the `rdf` gem.